### PR TITLE
2.2.5

### DIFF
--- a/CHANGED
+++ b/CHANGED
@@ -1,6 +1,6 @@
-Last Buienradar updates (05.08.2019)
+Last Buienradar updates (08.08.2019)
+  95d2b2e 08.08.2019 07:21 patch from inoma (https://forum.fhem.de/index.php/topic,102497.msg965120.html#msg965120)
+  c1af99c 05.08.2019 15:18 Release 2.2.3: [FHEMBUIENRADAR-31] generate data for GChart only on demand
   430a98f 05.08.2019 15:16 [FHEMBUIENRADAR-31] generate data for GChart only on demand, not every time a request is made
   45852c9 05.08.2019 14:56 Release 2.2.2: [FHEMBUIENRADAR-32]  support 0/1 for disabled also
   52251f8 05.08.2019 14:55 [FHEMBUIENRADAR-32] support 0/1 for disabled also
-  81bcc70 05.08.2019 14:22 [FHEMBUIENRADAR-12] release 2.2.1 with logProxy support
-  e3b3a16 05.08.2019 14:18 [FHEMBUIENRADAR-12] added support for logProxy

--- a/CHANGED
+++ b/CHANGED
@@ -1,6 +1,6 @@
 Last Buienradar updates (09.08.2019)
+  2a5b842 09.08.2019 11:18 https://forum.fhem.de/index.php/topic,102497.msg965554.html#msg965554
   65faed9 09.08.2019 11:05 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
   a10e927 09.08.2019 11:04 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
   a4b380b 09.08.2019 10:57 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
   ab46fb7 09.08.2019 10:39 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
-  5d03046 09.08.2019 10:34 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541

--- a/CHANGED
+++ b/CHANGED
@@ -1,6 +1,6 @@
 Last Buienradar updates (09.08.2019)
+  5d03046 09.08.2019 10:34 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
+  289bc7e 09.08.2019 09:51 v2.2.5 from inomi https://forum.fhem.de/index.php/topic,102497.msg965476.html#msg965476
   1eb5ac6 09.08.2019 09:49 v2.2.5 from inomi
   e9dc5f3 08.08.2019 07:36 patch from inoma (https://forum.fhem.de/index.php/topic,102497.msg965120.html#msg965120)
   95d2b2e 08.08.2019 07:21 patch from inoma (https://forum.fhem.de/index.php/topic,102497.msg965120.html#msg965120)
-  c1af99c 05.08.2019 15:18 Release 2.2.3: [FHEMBUIENRADAR-31] generate data for GChart only on demand
-  430a98f 05.08.2019 15:16 [FHEMBUIENRADAR-31] generate data for GChart only on demand, not every time a request is made

--- a/CHANGED
+++ b/CHANGED
@@ -1,6 +1,6 @@
 Last Buienradar updates (09.08.2019)
+  a10e927 09.08.2019 11:04 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
+  a4b380b 09.08.2019 10:57 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
   ab46fb7 09.08.2019 10:39 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
   5d03046 09.08.2019 10:34 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
   289bc7e 09.08.2019 09:51 v2.2.5 from inomi https://forum.fhem.de/index.php/topic,102497.msg965476.html#msg965476
-  1eb5ac6 09.08.2019 09:49 v2.2.5 from inomi
-  e9dc5f3 08.08.2019 07:36 patch from inoma (https://forum.fhem.de/index.php/topic,102497.msg965120.html#msg965120)

--- a/CHANGED
+++ b/CHANGED
@@ -1,6 +1,6 @@
-Last Buienradar updates (12.08.2019)
+Last Buienradar updates (18.08.2019)
+  345ad05 18.08.2019 20:15 Fix attribute "disabled" cannot be deleted
+  295ec76 18.08.2019 20:07 Fix attribute "disabled" cannot be deleted
+  1cfa34e 12.08.2019 18:11 fixed german docu
   d7fa774 12.08.2019 13:43 https://forum.fhem.de/index.php/topic,102497.msg965972.html#msg965972
   1d9f33c 09.08.2019 11:32 fixed english docu
-  2a5b842 09.08.2019 11:18 https://forum.fhem.de/index.php/topic,102497.msg965554.html#msg965554
-  65faed9 09.08.2019 11:05 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
-  a10e927 09.08.2019 11:04 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541

--- a/CHANGED
+++ b/CHANGED
@@ -1,6 +1,6 @@
-Last Buienradar updates (08.08.2019)
+Last Buienradar updates (09.08.2019)
+  1eb5ac6 09.08.2019 09:49 v2.2.5 from inomi
+  e9dc5f3 08.08.2019 07:36 patch from inoma (https://forum.fhem.de/index.php/topic,102497.msg965120.html#msg965120)
   95d2b2e 08.08.2019 07:21 patch from inoma (https://forum.fhem.de/index.php/topic,102497.msg965120.html#msg965120)
   c1af99c 05.08.2019 15:18 Release 2.2.3: [FHEMBUIENRADAR-31] generate data for GChart only on demand
   430a98f 05.08.2019 15:16 [FHEMBUIENRADAR-31] generate data for GChart only on demand, not every time a request is made
-  45852c9 05.08.2019 14:56 Release 2.2.2: [FHEMBUIENRADAR-32]  support 0/1 for disabled also
-  52251f8 05.08.2019 14:55 [FHEMBUIENRADAR-32] support 0/1 for disabled also

--- a/CHANGED
+++ b/CHANGED
@@ -1,6 +1,6 @@
-Last Buienradar updates (09.08.2019)
+Last Buienradar updates (12.08.2019)
+  d7fa774 12.08.2019 13:43 https://forum.fhem.de/index.php/topic,102497.msg965972.html#msg965972
+  1d9f33c 09.08.2019 11:32 fixed english docu
   2a5b842 09.08.2019 11:18 https://forum.fhem.de/index.php/topic,102497.msg965554.html#msg965554
   65faed9 09.08.2019 11:05 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
   a10e927 09.08.2019 11:04 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
-  a4b380b 09.08.2019 10:57 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
-  ab46fb7 09.08.2019 10:39 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541

--- a/CHANGED
+++ b/CHANGED
@@ -1,6 +1,6 @@
 Last Buienradar updates (09.08.2019)
+  ab46fb7 09.08.2019 10:39 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
   5d03046 09.08.2019 10:34 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
   289bc7e 09.08.2019 09:51 v2.2.5 from inomi https://forum.fhem.de/index.php/topic,102497.msg965476.html#msg965476
   1eb5ac6 09.08.2019 09:49 v2.2.5 from inomi
   e9dc5f3 08.08.2019 07:36 patch from inoma (https://forum.fhem.de/index.php/topic,102497.msg965120.html#msg965120)
-  95d2b2e 08.08.2019 07:21 patch from inoma (https://forum.fhem.de/index.php/topic,102497.msg965120.html#msg965120)

--- a/CHANGED
+++ b/CHANGED
@@ -1,6 +1,6 @@
 Last Buienradar updates (09.08.2019)
+  65faed9 09.08.2019 11:05 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
   a10e927 09.08.2019 11:04 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
   a4b380b 09.08.2019 10:57 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
   ab46fb7 09.08.2019 10:39 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
   5d03046 09.08.2019 10:34 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541
-  289bc7e 09.08.2019 09:51 v2.2.5 from inomi https://forum.fhem.de/index.php/topic,102497.msg965476.html#msg965476

--- a/CommandRef.de.md
+++ b/CommandRef.de.md
@@ -28,29 +28,37 @@ Aktuell lassen sich folgende Daten mit einem Get-Aufruf beziehen:
 
 ### Readings
 Aktuell liefert Buienradar folgende Readings:
-* ``rainAmount``    - Menge des gemeldeten Niederschlags in mm/h für den nächsten 5-Minuten-Intervall.
+* ``Begin``         - Beginn des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.
+* ``Duration``      - Zeitliche Dauer der gelieferten Niederschlagsdaten in HH:MM Format.
+* ``End``           - Ende des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.
+* ``rainAmount``    - Menge des gemeldeten Niederschlags in mm/h (= l/qm) für die nächste Stunde.
 * ``rainBegin``     - Beginn des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.
 * ``raindEnd``      - Ende des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.
 * ``rainDataStart`` - Zeitlicher Beginn der gelieferten Niederschlagsdaten.
 * ``rainDataEnd``   - Zeitliches Ende der gelieferten Niederschlagsdaten.
 * ``rainLaMetric``  - Aufbereitete Daten für LaMetric-Devices.
-* ``rainMax``       - Die maximale Niederschlagsmenge in mm/h für ein 5 Min. Intervall auf Basis der vorliegenden Daten.
-* ``rainNow``       - Die vorhergesagte Niederschlagsmenge für das aktuelle 5 Min. Intervall in mm/h.
-* ``rainTotal``     - Die gesamte vorhergesagte Niederschlagsmenge in mm/h
+* ``rainMax``       - Die maximale Niederschlagsmenge in mm für ein 5 Min. Intervall auf Basis der vorliegenden Daten.
+* ``rainNow``       - Die vorhergesagte Niederschlagsmenge für das aktuelle 5 Min. Intervall in mm.
+* ``rainTotal``     - Die gesamte vorhergesagte Niederschlagsmenge in mm.
 
 <span id="Buienradarattr" />
 
 ### Attribute
 
-* <a name="disabled"></a> ``disabled on|off``   - Wenn ``disabled`` auf `on` gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. ``off`` reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.
+* <a name="disabled"></a> ``disabled 1|0|on|off``   - Wenn ``disabled`` auf ``on`` oder ``1`` gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. ``off`` oder ``0`` reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.
 * <a name="region"></a> ``region nl|de`` - Erlaubte Werte sind ``nl`` (Standardwert) und ``de``. In einigen Fällen, insbesondere im Süden und Osten Deutschlands, liefert ``de`` überhaupt Werte.
-* <a name="interval"></a>  ``interval 10|60|120|180|240|300`` - Aktualisierung der Daten alle <var>n</var> Sekunden. **Achtung!** 10 Sekunden ist ein sehr aggressiver Wert und sollte mit Bedacht gewählt werden, <abbr>z.B.</abbr> bei der Fehlersuche. Standardwert sind 120 Sekunden. 
+* <a name="interval"></a>  ``interval 10|60|120|180|240|300|600`` - Aktualisierung der Daten alle <var>n</var> Sekunden. **Achtung!** 10 Sekunden ist ein sehr aggressiver Wert und sollte mit Bedacht gewählt werden, <abbr>z.B.</abbr> bei der Fehlersuche. Standardwert sind 120 Sekunden. 
 
 ### Visualisierungen
 Buienradar bietet neben der üblichen Ansicht als Device auch die Möglichkeit, die Daten als Charts in verschiedenen Formaten zu visualisieren.
-* Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit 
+* Eine HTML-"BAR"-Version, diese gibt einen HTML Balken mit einer farblichen Representation der Regenmenge aus und kann mit 
         
         { FHEM::Buienradar::HTML("name des buienradar device")}
+        
+    abgerufen werden.
+* Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit 
+        
+        { FHEM::Buienradar::BAR("name des buienradar device")}
         
     abgerufen werden.
 * Ein von Google Charts generiertes Diagramm im <abbr>PNG</abbr>-Format, welcher mit

--- a/CommandRef.de.md
+++ b/CommandRef.de.md
@@ -51,12 +51,12 @@ Aktuell liefert Buienradar folgende Readings:
 
 ### Visualisierungen
 Buienradar bietet neben der üblichen Ansicht als Device auch die Möglichkeit, die Daten als Charts in verschiedenen Formaten zu visualisieren.
-* Eine HTML-"BAR"-Version, diese gibt einen HTML Balken mit einer farblichen Representation der Regenmenge aus und kann mit 
+* Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit
         
         { FHEM::Buienradar::HTML("name des buienradar device")}
         
-    abgerufen werden.
-* Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit 
+    abgerufen werden kann.
+* Eine HTML-"BAR"-Version, diese gibt einen HTML Balken mit einer farblichen Representation der Regenmenge aus und kann mit
         
         { FHEM::Buienradar::BAR("name des buienradar device")}
         

--- a/CommandRef.en.md
+++ b/CommandRef.en.md
@@ -27,28 +27,37 @@ So the smallest possible definition is:
 
 ### Readings
 Buienradar provides several readings:
-* ``rainAmount``    - amount of predicted precipitation in mm/h for the next 5 minute interval.
+* ``Begin``         - Start of predicted precipitation in HH:MM format. If no precipitation is predicted, <var>unknown</var>.
+* ``Duration``      - Duration of predicted precipitation in HH:MM Format.
+* ``End``           - End of predicted precipitation in HH:MM format. If no precipitation is predicted, <var>unknown</var>.
+* ``rainAmount``    - amount of predicted precipitation in mm/h or l/qm for the next 1 hour interval.
 * ``rainBegin``     - starting time of the next precipitation, <var>unknown</var> if no precipitation is predicted.
 * ``raindEnd``      - ending time of the next precipitation, <var>unknown</var> if no precipitation is predicted.
 * ``rainDataStart`` - starting time of gathered data.
 * ``rainDataEnd``   - ending time of gathered data.
 * ``rainLaMetric``  - data formatted for a LaMetric device.
-* ``rainMax``       - maximal amount of precipitation for **any** 5 minute interval of the gathered data in mm/h.
-* ``rainNow``       - amount of precipitation for the **current** 5 minute interval in mm/h.
-* ``rainTotal``     - total amount of precipition for the gathered data in mm/h.
+* ``rainMax``       - maximal amount of precipitation for **any** 5 minute interval of the gathered data in mm.
+* ``rainNow``       - amount of precipitation for the **current** 5 minute interval in mm.
+* ``rainTotal``     - total amount of precipition for the gathered data in mm.
 
 <span id="Buienradarattr" />
 
 ### Attributes
-* <a name="disabled"></a> ``disabled on|off``   - If ``disabled`` is set to `on`, no further requests to Buienradar.nl will be performed. ``off`` reactivates the device, also if the attribute ist simply deleted.
+* <a name="disabled"></a> ``disabled 1|0|on|off``   - If ``disabled`` is set to ``on`` or ``1``, no further requests to Buienradar.nl will be performed. ``off`` or ``0`` reactivates the device, also if the attribute ist simply deleted.
 * <a name="region"></a> ``region nl|de`` - Allowed values are ``nl`` (default value) and ``de``. In some cases, especially in the south and east of Germany, ``de`` returns values at all.
-* <a name="interval"></a> ``interval 10|60|120|180|240|300`` - Data update every <var>n</var> seconds. **Attention!** 10 seconds is a very aggressive value and should be chosen carefully,  <abbr>e.g.</abbr> when troubleshooting. The default value is 120 seconds.  
+* <a name="interval"></a> ``interval 10|60|120|180|240|300|600`` - Data update every <var>n</var> seconds. **Attention!** 10 seconds is a very aggressive value and should be chosen carefully,  <abbr>e.g.</abbr> when troubleshooting. The default value is 120 seconds.  
 
 ### Visualisation
 Buienradar offers besides the usual view as device also the possibility to visualize the data as charts in different formats.
-* An HTML version that is displayed in the detail view by default and can be viewed with 
+* A HTML version that is displayed in the detail view by default and can be viewed with 
     
         { FHEM::Buienradar::HTML("buienradar device name")}
+
+    can be retrieved.
+    
+* A HTML-"BAR" version, which shows a HTML bar with coulored representation of rain amout and can be viewed with 
+    
+        { FHEM::Buienradar::BAR("buienradar device name")}
 
     can be retrieved.
     

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -903,72 +903,66 @@ sub Debugging {
 =begin html
 
 <p><span id="Buienradar"></span></p>
-<h2 id="buienradar">Buienradar</h2>
+<h2>Buienradar</h2>
 <p>Buienradar provides access to precipitation forecasts by the dutch service <a href="https://www.buienradar.nl">Buienradar.nl</a>.</p>
 <p><span id="Buienradardefine"></span></p>
-<h3 id="define">Define</h3>
+<h3>Define</h3>
 <pre><code>define &lt;devicename&gt; Buienradar [latitude] [longitude]</code></pre>
-<p><var>latitude</var> and <var>longitude</var> are facultative and will gathered from <var>global</var> if not set.<br>
-So the smallest possible definition is:</p>
+<p><var>latitude</var> and <var>longitude</var> are facultative and will gathered from <var>global</var> if not set. So the smallest possible definition is:</p>
 <pre><code>define &lt;devicename&gt; Buienradar</code></pre>
 <p><span id="Buienradarget"></span></p>
-<h3 id="get">Get</h3>
+<h3>Get</h3>
 <p><var>Get</var> will get you the following:</p>
 <ul>
-  <li><code>rainDuration</code> - predicted duration of the next precipitation in minutes.<br></li>
-  <li><code>startse</code> - next precipitation starts in <var>n</var> minutes. <strong>Obsolete!</strong><br></li>
-  <li><code>refresh</code> - get new data from Buienradar.nl.<br></li>
-  <li><code>version</code> - get current version of the Buienradar module.<br></li>
+  <li><code>rainDuration</code> - predicted duration of the next precipitation in minutes.</li>
+  <li><code>startse</code> - next precipitation starts in <var>n</var> minutes. <strong>Obsolete!</strong></li>
+  <li><code>refresh</code> - get new data from Buienradar.nl.</li>
+  <li><code>version</code> - get current version of the Buienradar module.</li>
   <li><code>testVal</code> - converts the gathered values from the old Buienradar <abbr>API</abbr> to mm/m². <strong>Obsolete!</strong></li>
 </ul>
 <p><span id="Buienradarreadings"></span></p>
-<h3 id="readings">Readings</h3>
+<h3>Readings</h3>
 <p>Buienradar provides several readings:</p>
 <ul>
-  <li><code>Begin</code> - Start of predicted precipitation in HH:MM format. If no precipitation is predicted, <var>unknown</var>.<br></li>
-  <li><code>Duration</code> - Duration of predicted precipitation in HH:MM Format.<br></li>
-  <li><code>End</code> - End of predicted precipitation in HH:MM format. If no precipitation is predicted, <var>unknown</var>.<br></li>
-  <li><code>rainAmount</code> - amount of predicted precipitation in mm/h or l/qm for the next 1 hour interval.<br></li>
-  <li><code>rainBegin</code> - starting time of the next precipitation, <var>unknown</var> if no precipitation is predicted.<br></li>
-  <li><code>raindEnd</code> - ending time of the next precipitation, <var>unknown</var> if no precipitation is predicted.<br></li>
-  <li><code>rainDataStart</code> - starting time of gathered data.<br></li>
-  <li><code>rainDataEnd</code> - ending time of gathered data.<br></li>
-  <li><code>rainDuration</code> - Duration of predicted precipitation in full time format.<br></li>
-  <li><code>rainDurationMin</code> - Duration of predicted precipitation in minutes.<br></li>
-  <li><code>rainLaMetric</code> - data formatted for a LaMetric device.<br></li>
-  <li><code>rainMax</code> - maximal amount of precipitation for <strong>any</strong> 5 minute interval of the gathered data in mm.<br></li>
-  <li><code>rainNow</code> - amount of precipitation for the <strong>current</strong> 5 minute interval in mm.<br></li>
-  <li><code>rainTotal</code> - total amount of precipition for the gathered data in mm.</li>
+  <li><code>rainAmount</code> - amount of predicted precipitation in mm/h for the next 5 minute interval.</li>
+  <li><code>rainBegin</code> - starting time of the next precipitation, <var>unknown</var> if no precipitation is predicted.</li>
+  <li><code>raindEnd</code> - ending time of the next precipitation, <var>unknown</var> if no precipitation is predicted.</li>
+  <li><code>rainDataStart</code> - starting time of gathered data.</li>
+  <li><code>rainDataEnd</code> - ending time of gathered data.</li>
+  <li><code>rainLaMetric</code> - data formatted for a LaMetric device.</li>
+  <li><code>rainMax</code> - maximal amount of precipitation for <strong>any</strong> 5 minute interval of the gathered data in mm/h.</li>
+  <li><code>rainNow</code> - amount of precipitation for the <strong>current</strong> 5 minute interval in mm/h.</li>
+  <li><code>rainTotal</code> - total amount of precipition for the gathered data in mm/h.</li>
 </ul>
 <p><span id="Buienradarattr"></span></p>
-<h3 id="attributes">Attributes</h3>
+<h3>Attributes</h3>
 <ul>
   <li>
-    <a name="disabled" id="disabled"></a> <code>disabled 1|0|on|off</code> - If <code>disabled</code> is set to <code>on or 1</code>, no further requests to Buienradar.nl will be performed. <code>off</code> reactivates the device, also if the attribute ist simply deleted.<br>
+    <a name="disabled" id="disabled"></a> <code>disabled on|off</code> - If <code>disabled</code> is set to <code>on</code>, no further requests to Buienradar.nl will be performed. <code>off</code> reactivates the device, also if the attribute ist simply deleted.
   </li>
   <li>
-    <a name="region" id="region"></a> <code>region nl|de</code> - Allowed values are <code>nl</code> (default value) and <code>de</code>. In some cases, especially in the south and east of Germany, <code>de</code> returns values at all.<br>
+    <a name="region" id="region"></a> <code>region nl|de</code> - Allowed values are <code>nl</code> (default value) and <code>de</code>. In some cases, especially in the south and east of Germany, <code>de</code> returns values at all.
   </li>
   <li>
-    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300|600</code> - Data update every <var>n</var> seconds. <strong>Attention!</strong> 10 seconds is a very aggressive value and should be chosen carefully, <abbr>e.g.</abbr> when troubleshooting. The default value is 120 seconds.
+    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300</code> - Data update every <var>n</var> seconds. <strong>Attention!</strong> 10 seconds is a very aggressive value and should be chosen carefully, <abbr>e.g.</abbr> when troubleshooting. The default value is 120 seconds.
   </li>
 </ul>
-<h3 id="visualisation">Visualisation</h3>
+<h3>Visualisation</h3>
 <p>Buienradar offers besides the usual view as device also the possibility to visualize the data as charts in different formats.</p>
 <ul>
   <li>
     <p>An HTML version that is displayed in the detail view by default and can be viewed with</p>
-    <pre><code>{ FHEM::Buienradar::HTML("buienradar device name")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::HTML("buienradar device name")}</code></pre>
     <p>can be retrieved.</p>
   </li>
   <li>
     <p>A chart generated by Google Charts in <abbr>PNG</abbr> format, which can be viewed with</p>
-    <pre><code>{ FHEM::Buienradar::GChart("buienradar device name")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::GChart("buienradar device name")}</code></pre>
     <p>can be retrieved. <strong>Caution!</strong> Please note that data is transferred to Google for this purpose!</p>
   </li>
   <li>
     <p><abbr>FTUI</abbr> is supported by the LogProxy format:</p>
-    <pre><code>{ FHEM::Buienradar::LogProxy("buienradar device name")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::LogProxy("buienradar device name")}</code></pre>
   </li>
 </ul>
 
@@ -977,76 +971,72 @@ So the smallest possible definition is:</p>
 =begin html_DE
 
 <p><span id="Buienradar"></span></p>
-<h2 id="buienradar">Buienradar</h2>
-<p>Das Buienradar-Modul bindet die Niederschlagsvorhersagedaten der freien <abbr title="Application Program Interface">API</abbr><br>
-von <a href="https://www.buienradar.nl">Buienradar.nl</a> an.</p>
+<h2>Buienradar</h2>
+<p>Das Buienradar-Modul bindet die Niederschlagsvorhersagedaten der freien <abbr title="Application Program Interface">API</abbr> von <a href="https://www.buienradar.nl">Buienradar.nl</a> an.</p>
 <p><span id="Buienradardefine"></span></p>
-<h3 id="define">Define</h3>
+<h3>Define</h3>
 <pre><code>define &lt;devicename&gt; Buienradar [latitude] [longitude]</code></pre>
-<p>Die Werte für latitude und longitude sind optional und werden, wenn nicht explizit angegeben, von <var>global</var> bezogen.<br>
-Die minimalste Definition lautet demnach:</p>
+<p>Die Werte für latitude und longitude sind optional und werden, wenn nicht explizit angegeben, von <var>global</var> bezogen. Die minimalste Definition lautet demnach:</p>
 <pre><code>define &lt;devicename&gt; Buienradar</code></pre>
 <p><span id="Buienradarget"></span></p>
-<h3 id="get">Get</h3>
+<h3>Get</h3>
 <p>Aktuell lassen sich folgende Daten mit einem Get-Aufruf beziehen:</p>
 <ul>
-  <li><code>rainDuration</code> - Die voraussichtliche Dauer des nächsten Niederschlags in Minuten.<br></li>
-  <li><code>startse</code> - Der nächste Niederschlag beginnt in <var>n</var> Minuten. <strong>Obsolet!</strong><br></li>
-  <li><code>refresh</code> - Neue Daten abfragen.<br></li>
-  <li><code>version</code> - Aktuelle Version abfragen.<br></li>
+  <li><code>rainDuration</code> - Die voraussichtliche Dauer des nächsten Niederschlags in Minuten.</li>
+  <li><code>startse</code> - Der nächste Niederschlag beginnt in <var>n</var> Minuten. <strong>Obsolet!</strong></li>
+  <li><code>refresh</code> - Neue Daten abfragen.</li>
+  <li><code>version</code> - Aktuelle Version abfragen.</li>
   <li><code>testVal</code> - Rechnet einen Buienradar-Wert zu Testzwecken in mm/m² um. Dies war für die alte <abbr>API</abbr> von Buienradar.nl nötig. <strong>Obsolet!</strong></li>
 </ul>
 <p><span id="Buienradarreadings"></span></p>
-<h3 id="readings">Readings</h3>
+<h3>Readings</h3>
 <p>Aktuell liefert Buienradar folgende Readings:</p>
 <ul>
-  <li><code>Begin</code> - Beginn des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
-  <li><code>Duration</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in HH:MM Format.<br></li>
-  <li><code>End</code> - Ende des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
-  <li><code>rainAmount</code> - Menge des gemeldeten Niederschlags in mm/h (= l/qm) für die nächste Stunde.<br></li>
-  <li><code>rainBegin</code> - Beginn des nächsten Niederschlag in YY-mm-dd HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
-  <li><code>raindEnd</code> - Ende des nächsten Niederschlag in YY-mm-dd HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
-  <li><code>rainDataStart</code> - Zeitlicher Beginn der gelieferten Niederschlagsdaten.<br></li>
-  <li><code>rainDataEnd</code> - Zeitliches Ende der gelieferten Niederschlagsdaten.<br></li>
-  <li><code>rainDuration</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in YY-mm-dd HH:MM format.<br></li>
-  <li><code>rainDurationMin</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in Minuten.<br></li>
-  <li><code>rainLaMetric</code> - Aufbereitete Daten für LaMetric-Devices.<br></li>
-  <li><code>rainMax</code> - Die maximale Niederschlagsmenge in mm für ein 5 Min. Intervall auf Basis der vorliegenden Daten.<br></li>
-  <li><code>rainNow</code> - Die vorhergesagte Niederschlagsmenge für das aktuelle 5 Min. Intervall in mm.<br></li>
-  <li><code>rainTotal</code> - Die gesamte vorhergesagte Niederschlagsmenge in mm</li>
+  <li><code>Begin</code> - Beginn des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
+  <li><code>Duration</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in HH:MM Format.</li>
+  <li><code>End</code> - Ende des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
+  <li><code>rainAmount</code> - Menge des gemeldeten Niederschlags in mm/h (= l/qm) für die nächste Stunde.</li>
+  <li><code>rainBegin</code> - Beginn des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
+  <li><code>raindEnd</code> - Ende des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
+  <li><code>rainDataStart</code> - Zeitlicher Beginn der gelieferten Niederschlagsdaten.</li>
+  <li><code>rainDataEnd</code> - Zeitliches Ende der gelieferten Niederschlagsdaten.</li>
+  <li><code>rainLaMetric</code> - Aufbereitete Daten für LaMetric-Devices.</li>
+  <li><code>rainMax</code> - Die maximale Niederschlagsmenge in mm für ein 5 Min. Intervall auf Basis der vorliegenden Daten.</li>
+  <li><code>rainNow</code> - Die vorhergesagte Niederschlagsmenge für das aktuelle 5 Min. Intervall in mm.</li>
+  <li><code>rainTotal</code> - Die gesamte vorhergesagte Niederschlagsmenge in mm.</li>
 </ul>
 <p><span id="Buienradarattr"></span></p>
-<h3 id="attribute">Attribute</h3>
+<h3>Attribute</h3>
 <ul>
   <li>
-    <a name="disabled" id="disabled"></a> <code>disabled 1|0|on|off</code> - Wenn <code>disabled</code> auf <code>on oder 1</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.<br>
+    <a name="disabled" id="disabled"></a> <code>disabled 1|0|on|off</code> - Wenn <code>disabled</code> auf <code>on</code> oder <code>1</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> oder <code>0</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.
   </li>
   <li>
-    <a name="region" id="region"></a> <code>region nl|de</code> - Erlaubte Werte sind <code>nl</code> (Standardwert) und <code>de</code>. In einigen Fällen, insbesondere im Süden und Osten Deutschlands, liefert <code>de</code> überhaupt Werte.<br>
+    <a name="region" id="region"></a> <code>region nl|de</code> - Erlaubte Werte sind <code>nl</code> (Standardwert) und <code>de</code>. In einigen Fällen, insbesondere im Süden und Osten Deutschlands, liefert <code>de</code> überhaupt Werte.
   </li>
   <li>
     <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300|600</code> - Aktualisierung der Daten alle <var>n</var> Sekunden. <strong>Achtung!</strong> 10 Sekunden ist ein sehr aggressiver Wert und sollte mit Bedacht gewählt werden, <abbr>z.B.</abbr> bei der Fehlersuche. Standardwert sind 120 Sekunden.
   </li>
 </ul>
-<h3 id="visualisierungen">Visualisierungen</h3>
+<h3>Visualisierungen</h3>
 <p>Buienradar bietet neben der üblichen Ansicht als Device auch die Möglichkeit, die Daten als Charts in verschiedenen Formaten zu visualisieren.</p>
 <ul>
   <li>
-    <p>Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit</p>
-    <pre><code>{ FHEM::Buienradar::HTML("name des buienradar device")}</code></pre>abgerufen werden.<br>
+    <p>Eine HTML-"BAR"-Version, diese gibt einen HTML Balken mit einer farblichen Representation der Regenmenge aus und kann mit</p>
+    <pre><code>  { FHEM::Buienradar::HTML("name des buienradar device")}</code></pre>abgerufen werden.
   </li>
   <li>
-    <p>Eine HTML-"BAR"-Version, diese gibt einen HTML Balken mit einer farblichen Representation der Regenmenge aus und kann mit</p>
-    <pre><code>{ FHEM::Buienradar::BAR("name des buienradar device")}</code></pre>abgerufen werden.<br>
+    <p>Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit</p>
+    <pre><code>  { FHEM::Buienradar::BAR("name des buienradar device")}</code></pre>abgerufen werden.
   </li>
   <li>
     <p>Ein von Google Charts generiertes Diagramm im <abbr>PNG</abbr>-Format, welcher mit</p>
-    <pre><code>{ FHEM::Buienradar::GChart("name des buienradar device")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::GChart("name des buienradar device")}</code></pre>
     <p>abgerufen werden kann. <strong>Achtung!</strong> Dazu werden Daten an Google übertragen!</p>
   </li>
   <li>
     <p>Für <abbr>FTUI</abbr> werden die Daten im LogProxy-Format bereitgestellt:</p>
-    <pre><code>{ FHEM::Buienradar::LogProxy("name des buienradar device")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::LogProxy("name des buienradar device")}</code></pre>
   </li>
 </ul>
 
@@ -1073,7 +1063,7 @@ Die minimalste Definition lautet demnach:</p>
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "2.2.3",
+    "version": "2.2.5",
     "author": [
         "Christoph Morrison <post@christoph-jeschke.de>"
     ],

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -992,35 +992,42 @@ sub Debugging {
 <h3>Readings</h3>
 <p>Aktuell liefert Buienradar folgende Readings:</p>
 <ul>
-  <li><code>rainAmount</code> - Menge des gemeldeten Niederschlags in mm/h für den nächsten 5-Minuten-Intervall.</li>
+  <li><code>Begin</code> - Beginn des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
+  <li><code>Duration</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in HH:MM Format.</li>
+  <li><code>End</code> - Ende des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
+  <li><code>rainAmount</code> - Menge des gemeldeten Niederschlags in mm/h (= l/qm) für die nächste Stunde.</li>
   <li><code>rainBegin</code> - Beginn des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
   <li><code>raindEnd</code> - Ende des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
   <li><code>rainDataStart</code> - Zeitlicher Beginn der gelieferten Niederschlagsdaten.</li>
   <li><code>rainDataEnd</code> - Zeitliches Ende der gelieferten Niederschlagsdaten.</li>
   <li><code>rainLaMetric</code> - Aufbereitete Daten für LaMetric-Devices.</li>
-  <li><code>rainMax</code> - Die maximale Niederschlagsmenge in mm/h für ein 5 Min. Intervall auf Basis der vorliegenden Daten.</li>
-  <li><code>rainNow</code> - Die vorhergesagte Niederschlagsmenge für das aktuelle 5 Min. Intervall in mm/h.</li>
-  <li><code>rainTotal</code> - Die gesamte vorhergesagte Niederschlagsmenge in mm/h</li>
+  <li><code>rainMax</code> - Die maximale Niederschlagsmenge in mm für ein 5 Min. Intervall auf Basis der vorliegenden Daten.</li>
+  <li><code>rainNow</code> - Die vorhergesagte Niederschlagsmenge für das aktuelle 5 Min. Intervall in mm.</li>
+  <li><code>rainTotal</code> - Die gesamte vorhergesagte Niederschlagsmenge in mm.</li>
 </ul>
 <p><span id="Buienradarattr"></span></p>
 <h3>Attribute</h3>
 <ul>
   <li>
-    <a name="disabled" id="disabled"></a> <code>disabled on|off</code> - Wenn <code>disabled</code> auf <code>on</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.
+    <a name="disabled" id="disabled"></a> <code>disabled 1|0|on|off</code> - Wenn <code>disabled</code> auf <code>on</code> oder <code>1</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> oder <code>0</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.
   </li>
   <li>
     <a name="region" id="region"></a> <code>region nl|de</code> - Erlaubte Werte sind <code>nl</code> (Standardwert) und <code>de</code>. In einigen Fällen, insbesondere im Süden und Osten Deutschlands, liefert <code>de</code> überhaupt Werte.
   </li>
   <li>
-    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300</code> - Aktualisierung der Daten alle <var>n</var> Sekunden. <strong>Achtung!</strong> 10 Sekunden ist ein sehr aggressiver Wert und sollte mit Bedacht gewählt werden, <abbr>z.B.</abbr> bei der Fehlersuche. Standardwert sind 120 Sekunden.
+    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300|600</code> - Aktualisierung der Daten alle <var>n</var> Sekunden. <strong>Achtung!</strong> 10 Sekunden ist ein sehr aggressiver Wert und sollte mit Bedacht gewählt werden, <abbr>z.B.</abbr> bei der Fehlersuche. Standardwert sind 120 Sekunden.
   </li>
 </ul>
 <h3>Visualisierungen</h3>
 <p>Buienradar bietet neben der üblichen Ansicht als Device auch die Möglichkeit, die Daten als Charts in verschiedenen Formaten zu visualisieren.</p>
 <ul>
   <li>
-    <p>Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit</p>
+    <p>Eine HTML-"BAR"-Version, diese gibt einen HTML Balken mit einer farblichen Representation der Regenmenge aus und kann mit</p>
     <pre><code>  { FHEM::Buienradar::HTML("name des buienradar device")}</code></pre>abgerufen werden.
+  </li>
+  <li>
+    <p>Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit</p>
+    <pre><code>  { FHEM::Buienradar::BAR("name des buienradar device")}</code></pre>abgerufen werden.
   </li>
   <li>
     <p>Ein von Google Charts generiertes Diagramm im <abbr>PNG</abbr>-Format, welcher mit</p>
@@ -1056,7 +1063,7 @@ sub Debugging {
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "author": [
         "Christoph Morrison <post@christoph-jeschke.de>"
     ],

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -1031,11 +1031,11 @@ sub Debugging {
 <p>Buienradar bietet neben der üblichen Ansicht als Device auch die Möglichkeit, die Daten als Charts in verschiedenen Formaten zu visualisieren.</p>
 <ul>
   <li>
-    <p>Eine HTML-"BAR"-Version, diese gibt einen HTML Balken mit einer farblichen Representation der Regenmenge aus und kann mit</p>
-    <pre><code>  { FHEM::Buienradar::HTML("name des buienradar device")}</code></pre>abgerufen werden.
+    <p>Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit</p>
+    <pre><code>  { FHEM::Buienradar::HTML("name des buienradar device")}</code></pre>abgerufen werden kann.
   </li>
   <li>
-    <p>Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit</p>
+    <p>Eine HTML-"BAR"-Version, diese gibt einen HTML Balken mit einer farblichen Representation der Regenmenge aus und kann mit</p>
     <pre><code>  { FHEM::Buienradar::BAR("name des buienradar device")}</code></pre>abgerufen werden.
   </li>
   <li>

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -808,7 +808,7 @@ sub ParseHttpResponse($) {
                 ::readingsBulkUpdate( $hash, "rainEnd", (($rainEnd) ? strftime "%Y-%m-%d %H:%M:%S", localtime $rainEnd : 'unknown'));
                 ::readingsBulkUpdate( $hash, "Begin", (($rainStart) ? strftime "%H:%M", localtime $rainStart : 'unknown'));
                 ::readingsBulkUpdate( $hash, "End", (($rainEnd) ? strftime "%H:%M", localtime $rainEnd : 'unknown'));
-                ::readingsBulkUpdate( $hash, "Duration", $rainDuration ));
+                ::readingsBulkUpdate( $hash, "Duration", $rainDuration );
                 ::readingsBulkUpdate( $hash, "rainDuration",  $rainDuration );
                 ::readingsBulkUpdate( $hash, "rainDurationMin",  $rainDurationMin );
                 ::readingsBulkUpdate( $hash, "rainData", $rainData);

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -724,7 +724,7 @@ sub ParseHttpResponse($) {
             my $forecast_start  = $dataStart;
             my $rainNow         = undef;
             my $rainData        = join(':', @precip);
-            my $rainAmount      = List::Util::sum @precip[0..11];#  $precip[0]; #$precip[0];
+            my $rainAmount      = 0;
             my $as_htmlBarhead  = '<tr style="font-size:x-small;"}>';
             my $as_htmlBar      = "";
             my $count           = 0;
@@ -757,6 +757,7 @@ sub ParseHttpResponse($) {
                   $as_htmlBar .= '<td style="padding-left: 0; padding-right: 0" bgcolor="' . myPrecip2RGB($a) . '">&nbsp;&nbsp;&nbsp;</td>';
                   #$as_htmlBar .= '<td bgcolor="' . myPrecip2RGB($a) . '">&nbsp;</td>';
                 }
+                if ($count < 12) { $rainAmount = $rainAmount + $precip;}
                 $count++;
 
                 if (!$rainStart and $precip > 0) {

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -297,9 +297,6 @@ sub Attr {
                 )
             );
 
-            #return "${attribute_value} is no valid value for disabled. Only 'on', '1', '0' or 'off' are allowed!"
-            #    if $attribute_value !~ /^(on|off|0|1)$/;
-
             given ($command) {
                 when ('set') {
                 

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -297,11 +297,15 @@ sub Attr {
                 )
             );
 
-            return "${attribute_value} is no valid value for disabled. Only 'on', '1', '0' or 'off' are allowed!"
-                if $attribute_value !~ /^(on|off|0|1)$/;
+            #return "${attribute_value} is no valid value for disabled. Only 'on', '1', '0' or 'off' are allowed!"
+            #    if $attribute_value !~ /^(on|off|0|1)$/;
 
             given ($command) {
                 when ('set') {
+                
+                return "${attribute_value} is no valid value for disabled. Only 'on', '1', '0' or 'off' are allowed!"
+                if $attribute_value !~ /^(on|off|0|1)$/;
+                
                     if ($attribute_value =~ /(on|1)/) {
                         ::RemoveInternalTimer( $hash, "FHEM::Buienradar::Timer" );
                         $hash->{NEXTUPDATE} = undef;

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -824,67 +824,66 @@ sub Debugging {
 =begin html
 
 <p><span id="Buienradar"></span></p>
-<h2 id="buienradar">Buienradar</h2>
+<h2>Buienradar</h2>
 <p>Buienradar provides access to precipitation forecasts by the dutch service <a href="https://www.buienradar.nl">Buienradar.nl</a>.</p>
 <p><span id="Buienradardefine"></span></p>
-<h3 id="define">Define</h3>
+<h3>Define</h3>
 <pre><code>define &lt;devicename&gt; Buienradar [latitude] [longitude]</code></pre>
-<p><var>latitude</var> and <var>longitude</var> are facultative and will gathered from <var>global</var> if not set.<br>
-So the smallest possible definition is:</p>
+<p><var>latitude</var> and <var>longitude</var> are facultative and will gathered from <var>global</var> if not set. So the smallest possible definition is:</p>
 <pre><code>define &lt;devicename&gt; Buienradar</code></pre>
 <p><span id="Buienradarget"></span></p>
-<h3 id="get">Get</h3>
+<h3>Get</h3>
 <p><var>Get</var> will get you the following:</p>
 <ul>
-  <li><code>rainDuration</code> - predicted duration of the next precipitation in minutes.<br></li>
-  <li><code>startse</code> - next precipitation starts in <var>n</var> minutes. <strong>Obsolete!</strong><br></li>
-  <li><code>refresh</code> - get new data from Buienradar.nl.<br></li>
-  <li><code>version</code> - get current version of the Buienradar module.<br></li>
+  <li><code>rainDuration</code> - predicted duration of the next precipitation in minutes.</li>
+  <li><code>startse</code> - next precipitation starts in <var>n</var> minutes. <strong>Obsolete!</strong></li>
+  <li><code>refresh</code> - get new data from Buienradar.nl.</li>
+  <li><code>version</code> - get current version of the Buienradar module.</li>
   <li><code>testVal</code> - converts the gathered values from the old Buienradar <abbr>API</abbr> to mm/m². <strong>Obsolete!</strong></li>
 </ul>
 <p><span id="Buienradarreadings"></span></p>
-<h3 id="readings">Readings</h3>
+<h3>Readings</h3>
 <p>Buienradar provides several readings:</p>
 <ul>
-  <li><code>rainAmount</code> - amount of predicted precipitation in mm/h for the next 5 minute interval.<br></li>
-  <li><code>rainBegin</code> - starting time of the next precipitation, <var>unknown</var> if no precipitation is predicted.<br></li>
-  <li><code>raindEnd</code> - ending time of the next precipitation, <var>unknown</var> if no precipitation is predicted.<br></li>
-  <li><code>rainDataStart</code> - starting time of gathered data.<br></li>
-  <li><code>rainDataEnd</code> - ending time of gathered data.<br></li>
-  <li><code>rainLaMetric</code> - data formatted for a LaMetric device.<br></li>
-  <li><code>rainMax</code> - maximal amount of precipitation for <strong>any</strong> 5 minute interval of the gathered data in mm/h.<br></li>
-  <li><code>rainNow</code> - amount of precipitation for the <strong>current</strong> 5 minute interval in mm/h.<br></li>
+  <li><code>rainAmount</code> - amount of predicted precipitation in mm/h for the next 5 minute interval.</li>
+  <li><code>rainBegin</code> - starting time of the next precipitation, <var>unknown</var> if no precipitation is predicted.</li>
+  <li><code>raindEnd</code> - ending time of the next precipitation, <var>unknown</var> if no precipitation is predicted.</li>
+  <li><code>rainDataStart</code> - starting time of gathered data.</li>
+  <li><code>rainDataEnd</code> - ending time of gathered data.</li>
+  <li><code>rainLaMetric</code> - data formatted for a LaMetric device.</li>
+  <li><code>rainMax</code> - maximal amount of precipitation for <strong>any</strong> 5 minute interval of the gathered data in mm/h.</li>
+  <li><code>rainNow</code> - amount of precipitation for the <strong>current</strong> 5 minute interval in mm/h.</li>
   <li><code>rainTotal</code> - total amount of precipition for the gathered data in mm/h.</li>
 </ul>
 <p><span id="Buienradarattr"></span></p>
-<h3 id="attributes">Attributes</h3>
+<h3>Attributes</h3>
 <ul>
   <li>
-    <a name="disabled" id="disabled"></a> <code>disabled on|off</code> - If <code>disabled</code> is set to <code>on</code>, no further requests to Buienradar.nl will be performed. <code>off</code> reactivates the device, also if the attribute ist simply deleted.<br>
+    <a name="disabled" id="disabled"></a> <code>disabled on|off</code> - If <code>disabled</code> is set to <code>on</code>, no further requests to Buienradar.nl will be performed. <code>off</code> reactivates the device, also if the attribute ist simply deleted.
   </li>
   <li>
-    <a name="region" id="region"></a> <code>region nl|de</code> - Allowed values are <code>nl</code> (default value) and <code>de</code>. In some cases, especially in the south and east of Germany, <code>de</code> returns values at all.<br>
+    <a name="region" id="region"></a> <code>region nl|de</code> - Allowed values are <code>nl</code> (default value) and <code>de</code>. In some cases, especially in the south and east of Germany, <code>de</code> returns values at all.
   </li>
   <li>
     <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300</code> - Data update every <var>n</var> seconds. <strong>Attention!</strong> 10 seconds is a very aggressive value and should be chosen carefully, <abbr>e.g.</abbr> when troubleshooting. The default value is 120 seconds.
   </li>
 </ul>
-<h3 id="visualisation">Visualisation</h3>
+<h3>Visualisation</h3>
 <p>Buienradar offers besides the usual view as device also the possibility to visualize the data as charts in different formats.</p>
 <ul>
   <li>
     <p>An HTML version that is displayed in the detail view by default and can be viewed with</p>
-    <pre><code>{ FHEM::Buienradar::HTML("buienradar device name")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::HTML("buienradar device name")}</code></pre>
     <p>can be retrieved.</p>
   </li>
   <li>
     <p>A chart generated by Google Charts in <abbr>PNG</abbr> format, which can be viewed with</p>
-    <pre><code>{ FHEM::Buienradar::GChart("buienradar device name")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::GChart("buienradar device name")}</code></pre>
     <p>can be retrieved. <strong>Caution!</strong> Please note that data is transferred to Google for this purpose!</p>
   </li>
   <li>
     <p><abbr>FTUI</abbr> is supported by the LogProxy format:</p>
-    <pre><code>{ FHEM::Buienradar::LogProxy("buienradar device name")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::LogProxy("buienradar device name")}</code></pre>
   </li>
 </ul>
 
@@ -893,67 +892,65 @@ So the smallest possible definition is:</p>
 =begin html_DE
 
 <p><span id="Buienradar"></span></p>
-<h2 id="buienradar">Buienradar</h2>
-<p>Das Buienradar-Modul bindet die Niederschlagsvorhersagedaten der freien <abbr title="Application Program Interface">API</abbr><br>
-von <a href="https://www.buienradar.nl">Buienradar.nl</a> an.</p>
+<h2>Buienradar</h2>
+<p>Das Buienradar-Modul bindet die Niederschlagsvorhersagedaten der freien <abbr title="Application Program Interface">API</abbr> von <a href="https://www.buienradar.nl">Buienradar.nl</a> an.</p>
 <p><span id="Buienradardefine"></span></p>
-<h3 id="define">Define</h3>
+<h3>Define</h3>
 <pre><code>define &lt;devicename&gt; Buienradar [latitude] [longitude]</code></pre>
-<p>Die Werte für latitude und longitude sind optional und werden, wenn nicht explizit angegeben, von <var>global</var> bezogen.<br>
-Die minimalste Definition lautet demnach:</p>
+<p>Die Werte für latitude und longitude sind optional und werden, wenn nicht explizit angegeben, von <var>global</var> bezogen. Die minimalste Definition lautet demnach:</p>
 <pre><code>define &lt;devicename&gt; Buienradar</code></pre>
 <p><span id="Buienradarget"></span></p>
-<h3 id="get">Get</h3>
+<h3>Get</h3>
 <p>Aktuell lassen sich folgende Daten mit einem Get-Aufruf beziehen:</p>
 <ul>
-  <li><code>rainDuration</code> - Die voraussichtliche Dauer des nächsten Niederschlags in Minuten.<br></li>
-  <li><code>startse</code> - Der nächste Niederschlag beginnt in <var>n</var> Minuten. <strong>Obsolet!</strong><br></li>
-  <li><code>refresh</code> - Neue Daten abfragen.<br></li>
-  <li><code>version</code> - Aktuelle Version abfragen.<br></li>
+  <li><code>rainDuration</code> - Die voraussichtliche Dauer des nächsten Niederschlags in Minuten.</li>
+  <li><code>startse</code> - Der nächste Niederschlag beginnt in <var>n</var> Minuten. <strong>Obsolet!</strong></li>
+  <li><code>refresh</code> - Neue Daten abfragen.</li>
+  <li><code>version</code> - Aktuelle Version abfragen.</li>
   <li><code>testVal</code> - Rechnet einen Buienradar-Wert zu Testzwecken in mm/m² um. Dies war für die alte <abbr>API</abbr> von Buienradar.nl nötig. <strong>Obsolet!</strong></li>
 </ul>
 <p><span id="Buienradarreadings"></span></p>
-<h3 id="readings">Readings</h3>
+<h3>Readings</h3>
 <p>Aktuell liefert Buienradar folgende Readings:</p>
 <ul>
-  <li><code>rainAmount</code> - Menge des gemeldeten Niederschlags in mm/h für den nächsten 5-Minuten-Intervall.<br></li>
-  <li><code>rainBegin</code> - Beginn des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
-  <li><code>raindEnd</code> - Ende des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
-  <li><code>rainDataStart</code> - Zeitlicher Beginn der gelieferten Niederschlagsdaten.<br></li>
-  <li><code>rainDataEnd</code> - Zeitliches Ende der gelieferten Niederschlagsdaten.<br></li>
-  <li><code>rainLaMetric</code> - Aufbereitete Daten für LaMetric-Devices.<br></li>
-  <li><code>rainMax</code> - Die maximale Niederschlagsmenge in mm/h für ein 5 Min. Intervall auf Basis der vorliegenden Daten.<br></li>
-  <li><code>rainNow</code> - Die vorhergesagte Niederschlagsmenge für das aktuelle 5 Min. Intervall in mm/h.<br></li>
+  <li><code>rainAmount</code> - Menge des gemeldeten Niederschlags in mm/h für den nächsten 5-Minuten-Intervall.</li>
+  <li><code>rainBegin</code> - Beginn des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
+  <li><code>raindEnd</code> - Ende des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
+  <li><code>rainDataStart</code> - Zeitlicher Beginn der gelieferten Niederschlagsdaten.</li>
+  <li><code>rainDataEnd</code> - Zeitliches Ende der gelieferten Niederschlagsdaten.</li>
+  <li><code>rainLaMetric</code> - Aufbereitete Daten für LaMetric-Devices.</li>
+  <li><code>rainMax</code> - Die maximale Niederschlagsmenge in mm/h für ein 5 Min. Intervall auf Basis der vorliegenden Daten.</li>
+  <li><code>rainNow</code> - Die vorhergesagte Niederschlagsmenge für das aktuelle 5 Min. Intervall in mm/h.</li>
   <li><code>rainTotal</code> - Die gesamte vorhergesagte Niederschlagsmenge in mm/h</li>
 </ul>
 <p><span id="Buienradarattr"></span></p>
-<h3 id="attribute">Attribute</h3>
+<h3>Attribute</h3>
 <ul>
   <li>
-    <a name="disabled" id="disabled"></a> <code>disabled on|off</code> - Wenn <code>disabled</code> auf <code>on</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.<br>
+    <a name="disabled" id="disabled"></a> <code>disabled on|off</code> - Wenn <code>disabled</code> auf <code>on</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.
   </li>
   <li>
-    <a name="region" id="region"></a> <code>region nl|de</code> - Erlaubte Werte sind <code>nl</code> (Standardwert) und <code>de</code>. In einigen Fällen, insbesondere im Süden und Osten Deutschlands, liefert <code>de</code> überhaupt Werte.<br>
+    <a name="region" id="region"></a> <code>region nl|de</code> - Erlaubte Werte sind <code>nl</code> (Standardwert) und <code>de</code>. In einigen Fällen, insbesondere im Süden und Osten Deutschlands, liefert <code>de</code> überhaupt Werte.
   </li>
   <li>
     <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300</code> - Aktualisierung der Daten alle <var>n</var> Sekunden. <strong>Achtung!</strong> 10 Sekunden ist ein sehr aggressiver Wert und sollte mit Bedacht gewählt werden, <abbr>z.B.</abbr> bei der Fehlersuche. Standardwert sind 120 Sekunden.
   </li>
 </ul>
-<h3 id="visualisierungen">Visualisierungen</h3>
+<h3>Visualisierungen</h3>
 <p>Buienradar bietet neben der üblichen Ansicht als Device auch die Möglichkeit, die Daten als Charts in verschiedenen Formaten zu visualisieren.</p>
 <ul>
   <li>
     <p>Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit</p>
-    <pre><code>{ FHEM::Buienradar::HTML("name des buienradar device")}</code></pre>abgerufen werden.<br>
+    <pre><code>  { FHEM::Buienradar::HTML("name des buienradar device")}</code></pre>abgerufen werden.
   </li>
   <li>
     <p>Ein von Google Charts generiertes Diagramm im <abbr>PNG</abbr>-Format, welcher mit</p>
-    <pre><code>{ FHEM::Buienradar::GChart("name des buienradar device")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::GChart("name des buienradar device")}</code></pre>
     <p>abgerufen werden kann. <strong>Achtung!</strong> Dazu werden Daten an Google übertragen!</p>
   </li>
   <li>
     <p>Für <abbr>FTUI</abbr> werden die Daten im LogProxy-Format bereitgestellt:</p>
-    <pre><code>{ FHEM::Buienradar::LogProxy("name des buienradar device")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::LogProxy("name des buienradar device")}</code></pre>
   </li>
 </ul>
 
@@ -980,7 +977,7 @@ Die minimalste Definition lautet demnach:</p>
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "2.2.3",
+    "version": "2.2.4",
     "author": [
         "Christoph Morrison <post@christoph-jeschke.de>"
     ],

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -924,35 +924,43 @@ sub Debugging {
 <h3>Readings</h3>
 <p>Buienradar provides several readings:</p>
 <ul>
-  <li><code>rainAmount</code> - amount of predicted precipitation in mm/h for the next 5 minute interval.</li>
+  <li><code>Begin</code> - Start of predicted precipitation in HH:MM format. If no precipitation is predicted, <var>unknown</var>.</li>
+  <li><code>Duration</code> - Duration of predicted precipitation in HH:MM Format.</li>
+  <li><code>End</code> - End of predicted precipitation in HH:MM format. If no precipitation is predicted, <var>unknown</var>.</li>
+  <li><code>rainAmount</code> - amount of predicted precipitation in mm/h or l/qm for the next 1 hour interval.</li>
   <li><code>rainBegin</code> - starting time of the next precipitation, <var>unknown</var> if no precipitation is predicted.</li>
   <li><code>raindEnd</code> - ending time of the next precipitation, <var>unknown</var> if no precipitation is predicted.</li>
   <li><code>rainDataStart</code> - starting time of gathered data.</li>
   <li><code>rainDataEnd</code> - ending time of gathered data.</li>
   <li><code>rainLaMetric</code> - data formatted for a LaMetric device.</li>
-  <li><code>rainMax</code> - maximal amount of precipitation for <strong>any</strong> 5 minute interval of the gathered data in mm/h.</li>
-  <li><code>rainNow</code> - amount of precipitation for the <strong>current</strong> 5 minute interval in mm/h.</li>
-  <li><code>rainTotal</code> - total amount of precipition for the gathered data in mm/h.</li>
+  <li><code>rainMax</code> - maximal amount of precipitation for <strong>any</strong> 5 minute interval of the gathered data in mm.</li>
+  <li><code>rainNow</code> - amount of precipitation for the <strong>current</strong> 5 minute interval in mm.</li>
+  <li><code>rainTotal</code> - total amount of precipition for the gathered data in mm.</li>
 </ul>
 <p><span id="Buienradarattr"></span></p>
 <h3>Attributes</h3>
 <ul>
   <li>
-    <a name="disabled" id="disabled"></a> <code>disabled on|off</code> - If <code>disabled</code> is set to <code>on</code>, no further requests to Buienradar.nl will be performed. <code>off</code> reactivates the device, also if the attribute ist simply deleted.
+    <a name="disabled" id="disabled"></a> <code>disabled 1|0|on|off</code> - If <code>disabled</code> is set to <code>on</code> or <code>1</code>, no further requests to Buienradar.nl will be performed. <code>off</code> or <code>0</code> reactivates the device, also if the attribute ist simply deleted.
   </li>
   <li>
     <a name="region" id="region"></a> <code>region nl|de</code> - Allowed values are <code>nl</code> (default value) and <code>de</code>. In some cases, especially in the south and east of Germany, <code>de</code> returns values at all.
   </li>
   <li>
-    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300</code> - Data update every <var>n</var> seconds. <strong>Attention!</strong> 10 seconds is a very aggressive value and should be chosen carefully, <abbr>e.g.</abbr> when troubleshooting. The default value is 120 seconds.
+    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300|600</code> - Data update every <var>n</var> seconds. <strong>Attention!</strong> 10 seconds is a very aggressive value and should be chosen carefully, <abbr>e.g.</abbr> when troubleshooting. The default value is 120 seconds.
   </li>
 </ul>
 <h3>Visualisation</h3>
 <p>Buienradar offers besides the usual view as device also the possibility to visualize the data as charts in different formats.</p>
 <ul>
   <li>
-    <p>An HTML version that is displayed in the detail view by default and can be viewed with</p>
+    <p>A HTML version that is displayed in the detail view by default and can be viewed with</p>
     <pre><code>  { FHEM::Buienradar::HTML("buienradar device name")}</code></pre>
+    <p>can be retrieved.</p>
+  </li>
+  <li>
+    <p>A HTML-"BAR" version, which shows a HTML bar with coulored representation of rain amout and can be viewed with</p>
+    <pre><code>  { FHEM::Buienradar::BAR("buienradar device name")}</code></pre>
     <p>can be retrieved.</p>
   </li>
   <li>

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -808,7 +808,7 @@ sub ParseHttpResponse($) {
                 ::readingsBulkUpdate( $hash, "rainEnd", (($rainEnd) ? strftime "%Y-%m-%d %H:%M:%S", localtime $rainEnd : 'unknown'));
                 ::readingsBulkUpdate( $hash, "Begin", (($rainStart) ? strftime "%H:%M", localtime $rainStart : 'unknown'));
                 ::readingsBulkUpdate( $hash, "End", (($rainEnd) ? strftime "%H:%M", localtime $rainEnd : 'unknown'));
-                ::readingsBulkUpdate( $hash, "Duration", (($rainStart && $rainEnd) ? strftime "%H:%M", localtime $rainDuration :'unknown'));
+                ::readingsBulkUpdate( $hash, "Duration", $rainDuration ));
                 ::readingsBulkUpdate( $hash, "rainDuration",  $rainDuration );
                 ::readingsBulkUpdate( $hash, "rainDurationMin",  $rainDurationMin );
                 ::readingsBulkUpdate( $hash, "rainData", $rainData);
@@ -903,66 +903,72 @@ sub Debugging {
 =begin html
 
 <p><span id="Buienradar"></span></p>
-<h2>Buienradar</h2>
+<h2 id="buienradar">Buienradar</h2>
 <p>Buienradar provides access to precipitation forecasts by the dutch service <a href="https://www.buienradar.nl">Buienradar.nl</a>.</p>
 <p><span id="Buienradardefine"></span></p>
-<h3>Define</h3>
+<h3 id="define">Define</h3>
 <pre><code>define &lt;devicename&gt; Buienradar [latitude] [longitude]</code></pre>
-<p><var>latitude</var> and <var>longitude</var> are facultative and will gathered from <var>global</var> if not set. So the smallest possible definition is:</p>
+<p><var>latitude</var> and <var>longitude</var> are facultative and will gathered from <var>global</var> if not set.<br>
+So the smallest possible definition is:</p>
 <pre><code>define &lt;devicename&gt; Buienradar</code></pre>
 <p><span id="Buienradarget"></span></p>
-<h3>Get</h3>
+<h3 id="get">Get</h3>
 <p><var>Get</var> will get you the following:</p>
 <ul>
-  <li><code>rainDuration</code> - predicted duration of the next precipitation in minutes.</li>
-  <li><code>startse</code> - next precipitation starts in <var>n</var> minutes. <strong>Obsolete!</strong></li>
-  <li><code>refresh</code> - get new data from Buienradar.nl.</li>
-  <li><code>version</code> - get current version of the Buienradar module.</li>
+  <li><code>rainDuration</code> - predicted duration of the next precipitation in minutes.<br></li>
+  <li><code>startse</code> - next precipitation starts in <var>n</var> minutes. <strong>Obsolete!</strong><br></li>
+  <li><code>refresh</code> - get new data from Buienradar.nl.<br></li>
+  <li><code>version</code> - get current version of the Buienradar module.<br></li>
   <li><code>testVal</code> - converts the gathered values from the old Buienradar <abbr>API</abbr> to mm/m². <strong>Obsolete!</strong></li>
 </ul>
 <p><span id="Buienradarreadings"></span></p>
-<h3>Readings</h3>
+<h3 id="readings">Readings</h3>
 <p>Buienradar provides several readings:</p>
 <ul>
-  <li><code>rainAmount</code> - amount of predicted precipitation in mm/h for the next 5 minute interval.</li>
-  <li><code>rainBegin</code> - starting time of the next precipitation, <var>unknown</var> if no precipitation is predicted.</li>
-  <li><code>raindEnd</code> - ending time of the next precipitation, <var>unknown</var> if no precipitation is predicted.</li>
-  <li><code>rainDataStart</code> - starting time of gathered data.</li>
-  <li><code>rainDataEnd</code> - ending time of gathered data.</li>
-  <li><code>rainLaMetric</code> - data formatted for a LaMetric device.</li>
-  <li><code>rainMax</code> - maximal amount of precipitation for <strong>any</strong> 5 minute interval of the gathered data in mm/h.</li>
-  <li><code>rainNow</code> - amount of precipitation for the <strong>current</strong> 5 minute interval in mm/h.</li>
-  <li><code>rainTotal</code> - total amount of precipition for the gathered data in mm/h.</li>
+  <li><code>Begin</code> - Start of predicted precipitation in HH:MM format. If no precipitation is predicted, <var>unknown</var>.<br></li>
+  <li><code>Duration</code> - Duration of predicted precipitation in HH:MM Format.<br></li>
+  <li><code>End</code> - End of predicted precipitation in HH:MM format. If no precipitation is predicted, <var>unknown</var>.<br></li>
+  <li><code>rainAmount</code> - amount of predicted precipitation in mm/h or l/qm for the next 1 hour interval.<br></li>
+  <li><code>rainBegin</code> - starting time of the next precipitation, <var>unknown</var> if no precipitation is predicted.<br></li>
+  <li><code>raindEnd</code> - ending time of the next precipitation, <var>unknown</var> if no precipitation is predicted.<br></li>
+  <li><code>rainDataStart</code> - starting time of gathered data.<br></li>
+  <li><code>rainDataEnd</code> - ending time of gathered data.<br></li>
+  <li><code>rainDuration</code> - Duration of predicted precipitation in full time format.<br></li>
+  <li><code>rainDurationMin</code> - Duration of predicted precipitation in minutes.<br></li>
+  <li><code>rainLaMetric</code> - data formatted for a LaMetric device.<br></li>
+  <li><code>rainMax</code> - maximal amount of precipitation for <strong>any</strong> 5 minute interval of the gathered data in mm.<br></li>
+  <li><code>rainNow</code> - amount of precipitation for the <strong>current</strong> 5 minute interval in mm.<br></li>
+  <li><code>rainTotal</code> - total amount of precipition for the gathered data in mm.</li>
 </ul>
 <p><span id="Buienradarattr"></span></p>
-<h3>Attributes</h3>
+<h3 id="attributes">Attributes</h3>
 <ul>
   <li>
-    <a name="disabled" id="disabled"></a> <code>disabled on|off</code> - If <code>disabled</code> is set to <code>on</code>, no further requests to Buienradar.nl will be performed. <code>off</code> reactivates the device, also if the attribute ist simply deleted.
+    <a name="disabled" id="disabled"></a> <code>disabled 1|0|on|off</code> - If <code>disabled</code> is set to <code>on or 1</code>, no further requests to Buienradar.nl will be performed. <code>off</code> reactivates the device, also if the attribute ist simply deleted.<br>
   </li>
   <li>
-    <a name="region" id="region"></a> <code>region nl|de</code> - Allowed values are <code>nl</code> (default value) and <code>de</code>. In some cases, especially in the south and east of Germany, <code>de</code> returns values at all.
+    <a name="region" id="region"></a> <code>region nl|de</code> - Allowed values are <code>nl</code> (default value) and <code>de</code>. In some cases, especially in the south and east of Germany, <code>de</code> returns values at all.<br>
   </li>
   <li>
-    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300</code> - Data update every <var>n</var> seconds. <strong>Attention!</strong> 10 seconds is a very aggressive value and should be chosen carefully, <abbr>e.g.</abbr> when troubleshooting. The default value is 120 seconds.
+    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300|600</code> - Data update every <var>n</var> seconds. <strong>Attention!</strong> 10 seconds is a very aggressive value and should be chosen carefully, <abbr>e.g.</abbr> when troubleshooting. The default value is 120 seconds.
   </li>
 </ul>
-<h3>Visualisation</h3>
+<h3 id="visualisation">Visualisation</h3>
 <p>Buienradar offers besides the usual view as device also the possibility to visualize the data as charts in different formats.</p>
 <ul>
   <li>
     <p>An HTML version that is displayed in the detail view by default and can be viewed with</p>
-    <pre><code>  { FHEM::Buienradar::HTML("buienradar device name")}</code></pre>
+    <pre><code>{ FHEM::Buienradar::HTML("buienradar device name")}</code></pre>
     <p>can be retrieved.</p>
   </li>
   <li>
     <p>A chart generated by Google Charts in <abbr>PNG</abbr> format, which can be viewed with</p>
-    <pre><code>  { FHEM::Buienradar::GChart("buienradar device name")}</code></pre>
+    <pre><code>{ FHEM::Buienradar::GChart("buienradar device name")}</code></pre>
     <p>can be retrieved. <strong>Caution!</strong> Please note that data is transferred to Google for this purpose!</p>
   </li>
   <li>
     <p><abbr>FTUI</abbr> is supported by the LogProxy format:</p>
-    <pre><code>  { FHEM::Buienradar::LogProxy("buienradar device name")}</code></pre>
+    <pre><code>{ FHEM::Buienradar::LogProxy("buienradar device name")}</code></pre>
   </li>
 </ul>
 
@@ -971,72 +977,76 @@ sub Debugging {
 =begin html_DE
 
 <p><span id="Buienradar"></span></p>
-<h2>Buienradar</h2>
-<p>Das Buienradar-Modul bindet die Niederschlagsvorhersagedaten der freien <abbr title="Application Program Interface">API</abbr> von <a href="https://www.buienradar.nl">Buienradar.nl</a> an.</p>
+<h2 id="buienradar">Buienradar</h2>
+<p>Das Buienradar-Modul bindet die Niederschlagsvorhersagedaten der freien <abbr title="Application Program Interface">API</abbr><br>
+von <a href="https://www.buienradar.nl">Buienradar.nl</a> an.</p>
 <p><span id="Buienradardefine"></span></p>
-<h3>Define</h3>
+<h3 id="define">Define</h3>
 <pre><code>define &lt;devicename&gt; Buienradar [latitude] [longitude]</code></pre>
-<p>Die Werte für latitude und longitude sind optional und werden, wenn nicht explizit angegeben, von <var>global</var> bezogen. Die minimalste Definition lautet demnach:</p>
+<p>Die Werte für latitude und longitude sind optional und werden, wenn nicht explizit angegeben, von <var>global</var> bezogen.<br>
+Die minimalste Definition lautet demnach:</p>
 <pre><code>define &lt;devicename&gt; Buienradar</code></pre>
 <p><span id="Buienradarget"></span></p>
-<h3>Get</h3>
+<h3 id="get">Get</h3>
 <p>Aktuell lassen sich folgende Daten mit einem Get-Aufruf beziehen:</p>
 <ul>
-  <li><code>rainDuration</code> - Die voraussichtliche Dauer des nächsten Niederschlags in Minuten.</li>
-  <li><code>startse</code> - Der nächste Niederschlag beginnt in <var>n</var> Minuten. <strong>Obsolet!</strong></li>
-  <li><code>refresh</code> - Neue Daten abfragen.</li>
-  <li><code>version</code> - Aktuelle Version abfragen.</li>
+  <li><code>rainDuration</code> - Die voraussichtliche Dauer des nächsten Niederschlags in Minuten.<br></li>
+  <li><code>startse</code> - Der nächste Niederschlag beginnt in <var>n</var> Minuten. <strong>Obsolet!</strong><br></li>
+  <li><code>refresh</code> - Neue Daten abfragen.<br></li>
+  <li><code>version</code> - Aktuelle Version abfragen.<br></li>
   <li><code>testVal</code> - Rechnet einen Buienradar-Wert zu Testzwecken in mm/m² um. Dies war für die alte <abbr>API</abbr> von Buienradar.nl nötig. <strong>Obsolet!</strong></li>
 </ul>
 <p><span id="Buienradarreadings"></span></p>
-<h3>Readings</h3>
+<h3 id="readings">Readings</h3>
 <p>Aktuell liefert Buienradar folgende Readings:</p>
 <ul>
-  <li><code>Begin</code> - Beginn des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
-  <li><code>Duration</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in HH:MM Format.</li>
-  <li><code>End</code> - Ende des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
-  <li><code>rainAmount</code> - Menge des gemeldeten Niederschlags in mm/h (= l/qm) für die nächste Stunde.</li>
-  <li><code>rainBegin</code> - Beginn des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
-  <li><code>raindEnd</code> - Ende des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
-  <li><code>rainDataStart</code> - Zeitlicher Beginn der gelieferten Niederschlagsdaten.</li>
-  <li><code>rainDataEnd</code> - Zeitliches Ende der gelieferten Niederschlagsdaten.</li>
-  <li><code>rainLaMetric</code> - Aufbereitete Daten für LaMetric-Devices.</li>
-  <li><code>rainMax</code> - Die maximale Niederschlagsmenge in mm für ein 5 Min. Intervall auf Basis der vorliegenden Daten.</li>
-  <li><code>rainNow</code> - Die vorhergesagte Niederschlagsmenge für das aktuelle 5 Min. Intervall in mm.</li>
-  <li><code>rainTotal</code> - Die gesamte vorhergesagte Niederschlagsmenge in mm.</li>
+  <li><code>Begin</code> - Beginn des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
+  <li><code>Duration</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in HH:MM Format.<br></li>
+  <li><code>End</code> - Ende des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
+  <li><code>rainAmount</code> - Menge des gemeldeten Niederschlags in mm/h (= l/qm) für die nächste Stunde.<br></li>
+  <li><code>rainBegin</code> - Beginn des nächsten Niederschlag in YY-mm-dd HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
+  <li><code>raindEnd</code> - Ende des nächsten Niederschlag in YY-mm-dd HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
+  <li><code>rainDataStart</code> - Zeitlicher Beginn der gelieferten Niederschlagsdaten.<br></li>
+  <li><code>rainDataEnd</code> - Zeitliches Ende der gelieferten Niederschlagsdaten.<br></li>
+  <li><code>rainDuration</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in YY-mm-dd HH:MM format.<br></li>
+  <li><code>rainDurationMin</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in Minuten.<br></li>
+  <li><code>rainLaMetric</code> - Aufbereitete Daten für LaMetric-Devices.<br></li>
+  <li><code>rainMax</code> - Die maximale Niederschlagsmenge in mm für ein 5 Min. Intervall auf Basis der vorliegenden Daten.<br></li>
+  <li><code>rainNow</code> - Die vorhergesagte Niederschlagsmenge für das aktuelle 5 Min. Intervall in mm.<br></li>
+  <li><code>rainTotal</code> - Die gesamte vorhergesagte Niederschlagsmenge in mm</li>
 </ul>
 <p><span id="Buienradarattr"></span></p>
-<h3>Attribute</h3>
+<h3 id="attribute">Attribute</h3>
 <ul>
   <li>
-    <a name="disabled" id="disabled"></a> <code>disabled 1|0|on|off</code> - Wenn <code>disabled</code> auf <code>on</code> oder <code>1</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> oder <code>0</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.
+    <a name="disabled" id="disabled"></a> <code>disabled 1|0|on|off</code> - Wenn <code>disabled</code> auf <code>on oder 1</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.<br>
   </li>
   <li>
-    <a name="region" id="region"></a> <code>region nl|de</code> - Erlaubte Werte sind <code>nl</code> (Standardwert) und <code>de</code>. In einigen Fällen, insbesondere im Süden und Osten Deutschlands, liefert <code>de</code> überhaupt Werte.
+    <a name="region" id="region"></a> <code>region nl|de</code> - Erlaubte Werte sind <code>nl</code> (Standardwert) und <code>de</code>. In einigen Fällen, insbesondere im Süden und Osten Deutschlands, liefert <code>de</code> überhaupt Werte.<br>
   </li>
   <li>
     <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300|600</code> - Aktualisierung der Daten alle <var>n</var> Sekunden. <strong>Achtung!</strong> 10 Sekunden ist ein sehr aggressiver Wert und sollte mit Bedacht gewählt werden, <abbr>z.B.</abbr> bei der Fehlersuche. Standardwert sind 120 Sekunden.
   </li>
 </ul>
-<h3>Visualisierungen</h3>
+<h3 id="visualisierungen">Visualisierungen</h3>
 <p>Buienradar bietet neben der üblichen Ansicht als Device auch die Möglichkeit, die Daten als Charts in verschiedenen Formaten zu visualisieren.</p>
 <ul>
   <li>
-    <p>Eine HTML-"BAR"-Version, diese gibt einen HTML Balken mit einer farblichen Representation der Regenmenge aus und kann mit</p>
-    <pre><code>  { FHEM::Buienradar::HTML("name des buienradar device")}</code></pre>abgerufen werden.
+    <p>Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit</p>
+    <pre><code>{ FHEM::Buienradar::HTML("name des buienradar device")}</code></pre>abgerufen werden.<br>
   </li>
   <li>
-    <p>Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit</p>
-    <pre><code>  { FHEM::Buienradar::BAR("name des buienradar device")}</code></pre>abgerufen werden.
+    <p>Eine HTML-"BAR"-Version, diese gibt einen HTML Balken mit einer farblichen Representation der Regenmenge aus und kann mit</p>
+    <pre><code>{ FHEM::Buienradar::BAR("name des buienradar device")}</code></pre>abgerufen werden.<br>
   </li>
   <li>
     <p>Ein von Google Charts generiertes Diagramm im <abbr>PNG</abbr>-Format, welcher mit</p>
-    <pre><code>  { FHEM::Buienradar::GChart("name des buienradar device")}</code></pre>
+    <pre><code>{ FHEM::Buienradar::GChart("name des buienradar device")}</code></pre>
     <p>abgerufen werden kann. <strong>Achtung!</strong> Dazu werden Daten an Google übertragen!</p>
   </li>
   <li>
     <p>Für <abbr>FTUI</abbr> werden die Daten im LogProxy-Format bereitgestellt:</p>
-    <pre><code>  { FHEM::Buienradar::LogProxy("name des buienradar device")}</code></pre>
+    <pre><code>{ FHEM::Buienradar::LogProxy("name des buienradar device")}</code></pre>
   </li>
 </ul>
 
@@ -1063,7 +1073,7 @@ sub Debugging {
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "2.2.5",
+    "version": "2.2.3",
     "author": [
         "Christoph Morrison <post@christoph-jeschke.de>"
     ],

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -808,7 +808,7 @@ sub ParseHttpResponse($) {
                 ::readingsBulkUpdate( $hash, "rainEnd", (($rainEnd) ? strftime "%Y-%m-%d %H:%M:%S", localtime $rainEnd : 'unknown'));
                 ::readingsBulkUpdate( $hash, "Begin", (($rainStart) ? strftime "%H:%M", localtime $rainStart : 'unknown'));
                 ::readingsBulkUpdate( $hash, "End", (($rainEnd) ? strftime "%H:%M", localtime $rainEnd : 'unknown'));
-                ::readingsBulkUpdate( $hash, "Duration",  strftime "%H:%M", localtime $rainDuration );
+                ::readingsBulkUpdate( $hash, "Duration", (($rainStart && $rainEnd) ? strftime "%H:%M", localtime $rainDuration :'unknown'));
                 ::readingsBulkUpdate( $hash, "rainDuration",  $rainDuration );
                 ::readingsBulkUpdate( $hash, "rainDurationMin",  $rainDurationMin );
                 ::readingsBulkUpdate( $hash, "rainData", $rainData);
@@ -903,66 +903,72 @@ sub Debugging {
 =begin html
 
 <p><span id="Buienradar"></span></p>
-<h2>Buienradar</h2>
+<h2 id="buienradar">Buienradar</h2>
 <p>Buienradar provides access to precipitation forecasts by the dutch service <a href="https://www.buienradar.nl">Buienradar.nl</a>.</p>
 <p><span id="Buienradardefine"></span></p>
-<h3>Define</h3>
+<h3 id="define">Define</h3>
 <pre><code>define &lt;devicename&gt; Buienradar [latitude] [longitude]</code></pre>
-<p><var>latitude</var> and <var>longitude</var> are facultative and will gathered from <var>global</var> if not set. So the smallest possible definition is:</p>
+<p><var>latitude</var> and <var>longitude</var> are facultative and will gathered from <var>global</var> if not set.<br>
+So the smallest possible definition is:</p>
 <pre><code>define &lt;devicename&gt; Buienradar</code></pre>
 <p><span id="Buienradarget"></span></p>
-<h3>Get</h3>
+<h3 id="get">Get</h3>
 <p><var>Get</var> will get you the following:</p>
 <ul>
-  <li><code>rainDuration</code> - predicted duration of the next precipitation in minutes.</li>
-  <li><code>startse</code> - next precipitation starts in <var>n</var> minutes. <strong>Obsolete!</strong></li>
-  <li><code>refresh</code> - get new data from Buienradar.nl.</li>
-  <li><code>version</code> - get current version of the Buienradar module.</li>
+  <li><code>rainDuration</code> - predicted duration of the next precipitation in minutes.<br></li>
+  <li><code>startse</code> - next precipitation starts in <var>n</var> minutes. <strong>Obsolete!</strong><br></li>
+  <li><code>refresh</code> - get new data from Buienradar.nl.<br></li>
+  <li><code>version</code> - get current version of the Buienradar module.<br></li>
   <li><code>testVal</code> - converts the gathered values from the old Buienradar <abbr>API</abbr> to mm/m². <strong>Obsolete!</strong></li>
 </ul>
 <p><span id="Buienradarreadings"></span></p>
-<h3>Readings</h3>
+<h3 id="readings">Readings</h3>
 <p>Buienradar provides several readings:</p>
 <ul>
-  <li><code>rainAmount</code> - amount of predicted precipitation in mm/h for the next 5 minute interval.</li>
-  <li><code>rainBegin</code> - starting time of the next precipitation, <var>unknown</var> if no precipitation is predicted.</li>
-  <li><code>raindEnd</code> - ending time of the next precipitation, <var>unknown</var> if no precipitation is predicted.</li>
-  <li><code>rainDataStart</code> - starting time of gathered data.</li>
-  <li><code>rainDataEnd</code> - ending time of gathered data.</li>
-  <li><code>rainLaMetric</code> - data formatted for a LaMetric device.</li>
-  <li><code>rainMax</code> - maximal amount of precipitation for <strong>any</strong> 5 minute interval of the gathered data in mm/h.</li>
-  <li><code>rainNow</code> - amount of precipitation for the <strong>current</strong> 5 minute interval in mm/h.</li>
-  <li><code>rainTotal</code> - total amount of precipition for the gathered data in mm/h.</li>
+  <li><code>Begin</code> - Start of predicted precipitation in HH:MM format. If no precipitation is predicted, <var>unknown</var>.<br></li>
+  <li><code>Duration</code> - Duration of predicted precipitation in HH:MM Format.<br></li>
+  <li><code>End</code> - End of predicted precipitation in HH:MM format. If no precipitation is predicted, <var>unknown</var>.<br></li>
+  <li><code>rainAmount</code> - amount of predicted precipitation in mm/h or l/qm for the next 1 hour interval.<br></li>
+  <li><code>rainBegin</code> - starting time of the next precipitation, <var>unknown</var> if no precipitation is predicted.<br></li>
+  <li><code>raindEnd</code> - ending time of the next precipitation, <var>unknown</var> if no precipitation is predicted.<br></li>
+  <li><code>rainDataStart</code> - starting time of gathered data.<br></li>
+  <li><code>rainDataEnd</code> - ending time of gathered data.<br></li>
+  <li><code>rainDuration</code> - Duration of predicted precipitation in full time format.<br></li>
+  <li><code>rainDurationMin</code> - Duration of predicted precipitation in minutes.<br></li>
+  <li><code>rainLaMetric</code> - data formatted for a LaMetric device.<br></li>
+  <li><code>rainMax</code> - maximal amount of precipitation for <strong>any</strong> 5 minute interval of the gathered data in mm.<br></li>
+  <li><code>rainNow</code> - amount of precipitation for the <strong>current</strong> 5 minute interval in mm.<br></li>
+  <li><code>rainTotal</code> - total amount of precipition for the gathered data in mm.</li>
 </ul>
 <p><span id="Buienradarattr"></span></p>
-<h3>Attributes</h3>
+<h3 id="attributes">Attributes</h3>
 <ul>
   <li>
-    <a name="disabled" id="disabled"></a> <code>disabled on|off</code> - If <code>disabled</code> is set to <code>on</code>, no further requests to Buienradar.nl will be performed. <code>off</code> reactivates the device, also if the attribute ist simply deleted.
+    <a name="disabled" id="disabled"></a> <code>disabled 1|0|on|off</code> - If <code>disabled</code> is set to <code>on or 1</code>, no further requests to Buienradar.nl will be performed. <code>off</code> reactivates the device, also if the attribute ist simply deleted.<br>
   </li>
   <li>
-    <a name="region" id="region"></a> <code>region nl|de</code> - Allowed values are <code>nl</code> (default value) and <code>de</code>. In some cases, especially in the south and east of Germany, <code>de</code> returns values at all.
+    <a name="region" id="region"></a> <code>region nl|de</code> - Allowed values are <code>nl</code> (default value) and <code>de</code>. In some cases, especially in the south and east of Germany, <code>de</code> returns values at all.<br>
   </li>
   <li>
-    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300</code> - Data update every <var>n</var> seconds. <strong>Attention!</strong> 10 seconds is a very aggressive value and should be chosen carefully, <abbr>e.g.</abbr> when troubleshooting. The default value is 120 seconds.
+    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300|600</code> - Data update every <var>n</var> seconds. <strong>Attention!</strong> 10 seconds is a very aggressive value and should be chosen carefully, <abbr>e.g.</abbr> when troubleshooting. The default value is 120 seconds.
   </li>
 </ul>
-<h3>Visualisation</h3>
+<h3 id="visualisation">Visualisation</h3>
 <p>Buienradar offers besides the usual view as device also the possibility to visualize the data as charts in different formats.</p>
 <ul>
   <li>
     <p>An HTML version that is displayed in the detail view by default and can be viewed with</p>
-    <pre><code>  { FHEM::Buienradar::HTML("buienradar device name")}</code></pre>
+    <pre><code>{ FHEM::Buienradar::HTML("buienradar device name")}</code></pre>
     <p>can be retrieved.</p>
   </li>
   <li>
     <p>A chart generated by Google Charts in <abbr>PNG</abbr> format, which can be viewed with</p>
-    <pre><code>  { FHEM::Buienradar::GChart("buienradar device name")}</code></pre>
+    <pre><code>{ FHEM::Buienradar::GChart("buienradar device name")}</code></pre>
     <p>can be retrieved. <strong>Caution!</strong> Please note that data is transferred to Google for this purpose!</p>
   </li>
   <li>
     <p><abbr>FTUI</abbr> is supported by the LogProxy format:</p>
-    <pre><code>  { FHEM::Buienradar::LogProxy("buienradar device name")}</code></pre>
+    <pre><code>{ FHEM::Buienradar::LogProxy("buienradar device name")}</code></pre>
   </li>
 </ul>
 
@@ -971,65 +977,76 @@ sub Debugging {
 =begin html_DE
 
 <p><span id="Buienradar"></span></p>
-<h2>Buienradar</h2>
-<p>Das Buienradar-Modul bindet die Niederschlagsvorhersagedaten der freien <abbr title="Application Program Interface">API</abbr> von <a href="https://www.buienradar.nl">Buienradar.nl</a> an.</p>
+<h2 id="buienradar">Buienradar</h2>
+<p>Das Buienradar-Modul bindet die Niederschlagsvorhersagedaten der freien <abbr title="Application Program Interface">API</abbr><br>
+von <a href="https://www.buienradar.nl">Buienradar.nl</a> an.</p>
 <p><span id="Buienradardefine"></span></p>
-<h3>Define</h3>
+<h3 id="define">Define</h3>
 <pre><code>define &lt;devicename&gt; Buienradar [latitude] [longitude]</code></pre>
-<p>Die Werte für latitude und longitude sind optional und werden, wenn nicht explizit angegeben, von <var>global</var> bezogen. Die minimalste Definition lautet demnach:</p>
+<p>Die Werte für latitude und longitude sind optional und werden, wenn nicht explizit angegeben, von <var>global</var> bezogen.<br>
+Die minimalste Definition lautet demnach:</p>
 <pre><code>define &lt;devicename&gt; Buienradar</code></pre>
 <p><span id="Buienradarget"></span></p>
-<h3>Get</h3>
+<h3 id="get">Get</h3>
 <p>Aktuell lassen sich folgende Daten mit einem Get-Aufruf beziehen:</p>
 <ul>
-  <li><code>rainDuration</code> - Die voraussichtliche Dauer des nächsten Niederschlags in Minuten.</li>
-  <li><code>startse</code> - Der nächste Niederschlag beginnt in <var>n</var> Minuten. <strong>Obsolet!</strong></li>
-  <li><code>refresh</code> - Neue Daten abfragen.</li>
-  <li><code>version</code> - Aktuelle Version abfragen.</li>
+  <li><code>rainDuration</code> - Die voraussichtliche Dauer des nächsten Niederschlags in Minuten.<br></li>
+  <li><code>startse</code> - Der nächste Niederschlag beginnt in <var>n</var> Minuten. <strong>Obsolet!</strong><br></li>
+  <li><code>refresh</code> - Neue Daten abfragen.<br></li>
+  <li><code>version</code> - Aktuelle Version abfragen.<br></li>
   <li><code>testVal</code> - Rechnet einen Buienradar-Wert zu Testzwecken in mm/m² um. Dies war für die alte <abbr>API</abbr> von Buienradar.nl nötig. <strong>Obsolet!</strong></li>
 </ul>
 <p><span id="Buienradarreadings"></span></p>
-<h3>Readings</h3>
+<h3 id="readings">Readings</h3>
 <p>Aktuell liefert Buienradar folgende Readings:</p>
 <ul>
-  <li><code>rainAmount</code> - Menge des gemeldeten Niederschlags in mm/h für den nächsten 5-Minuten-Intervall.</li>
-  <li><code>rainBegin</code> - Beginn des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
-  <li><code>raindEnd</code> - Ende des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
-  <li><code>rainDataStart</code> - Zeitlicher Beginn der gelieferten Niederschlagsdaten.</li>
-  <li><code>rainDataEnd</code> - Zeitliches Ende der gelieferten Niederschlagsdaten.</li>
-  <li><code>rainLaMetric</code> - Aufbereitete Daten für LaMetric-Devices.</li>
-  <li><code>rainMax</code> - Die maximale Niederschlagsmenge in mm/h für ein 5 Min. Intervall auf Basis der vorliegenden Daten.</li>
-  <li><code>rainNow</code> - Die vorhergesagte Niederschlagsmenge für das aktuelle 5 Min. Intervall in mm/h.</li>
-  <li><code>rainTotal</code> - Die gesamte vorhergesagte Niederschlagsmenge in mm/h</li>
+  <li><code>Begin</code> - Beginn des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
+  <li><code>Duration</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in HH:MM Format.<br></li>
+  <li><code>End</code> - Ende des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
+  <li><code>rainAmount</code> - Menge des gemeldeten Niederschlags in mm/h (= l/qm) für die nächste Stunde.<br></li>
+  <li><code>rainBegin</code> - Beginn des nächsten Niederschlag in YY-mm-dd HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
+  <li><code>raindEnd</code> - Ende des nächsten Niederschlag in YY-mm-dd HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
+  <li><code>rainDataStart</code> - Zeitlicher Beginn der gelieferten Niederschlagsdaten.<br></li>
+  <li><code>rainDataEnd</code> - Zeitliches Ende der gelieferten Niederschlagsdaten.<br></li>
+  <li><code>rainDuration</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in YY-mm-dd HH:MM format.<br></li>
+  <li><code>rainDurationMin</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in Minuten.<br></li>
+  <li><code>rainLaMetric</code> - Aufbereitete Daten für LaMetric-Devices.<br></li>
+  <li><code>rainMax</code> - Die maximale Niederschlagsmenge in mm für ein 5 Min. Intervall auf Basis der vorliegenden Daten.<br></li>
+  <li><code>rainNow</code> - Die vorhergesagte Niederschlagsmenge für das aktuelle 5 Min. Intervall in mm.<br></li>
+  <li><code>rainTotal</code> - Die gesamte vorhergesagte Niederschlagsmenge in mm</li>
 </ul>
 <p><span id="Buienradarattr"></span></p>
-<h3>Attribute</h3>
+<h3 id="attribute">Attribute</h3>
 <ul>
   <li>
-    <a name="disabled" id="disabled"></a> <code>disabled on|off</code> - Wenn <code>disabled</code> auf <code>on</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.
+    <a name="disabled" id="disabled"></a> <code>disabled 1|0|on|off</code> - Wenn <code>disabled</code> auf <code>on oder 1</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.<br>
   </li>
   <li>
-    <a name="region" id="region"></a> <code>region nl|de</code> - Erlaubte Werte sind <code>nl</code> (Standardwert) und <code>de</code>. In einigen Fällen, insbesondere im Süden und Osten Deutschlands, liefert <code>de</code> überhaupt Werte.
+    <a name="region" id="region"></a> <code>region nl|de</code> - Erlaubte Werte sind <code>nl</code> (Standardwert) und <code>de</code>. In einigen Fällen, insbesondere im Süden und Osten Deutschlands, liefert <code>de</code> überhaupt Werte.<br>
   </li>
   <li>
-    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300</code> - Aktualisierung der Daten alle <var>n</var> Sekunden. <strong>Achtung!</strong> 10 Sekunden ist ein sehr aggressiver Wert und sollte mit Bedacht gewählt werden, <abbr>z.B.</abbr> bei der Fehlersuche. Standardwert sind 120 Sekunden.
+    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300|600</code> - Aktualisierung der Daten alle <var>n</var> Sekunden. <strong>Achtung!</strong> 10 Sekunden ist ein sehr aggressiver Wert und sollte mit Bedacht gewählt werden, <abbr>z.B.</abbr> bei der Fehlersuche. Standardwert sind 120 Sekunden.
   </li>
 </ul>
-<h3>Visualisierungen</h3>
+<h3 id="visualisierungen">Visualisierungen</h3>
 <p>Buienradar bietet neben der üblichen Ansicht als Device auch die Möglichkeit, die Daten als Charts in verschiedenen Formaten zu visualisieren.</p>
 <ul>
   <li>
     <p>Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit</p>
-    <pre><code>  { FHEM::Buienradar::HTML("name des buienradar device")}</code></pre>abgerufen werden.
+    <pre><code>{ FHEM::Buienradar::HTML("name des buienradar device")}</code></pre>abgerufen werden.<br>
+  </li>
+  <li>
+    <p>Eine HTML-"BAR"-Version, diese gibt einen HTML Balken mit einer farblichen Representation der Regenmenge aus und kann mit</p>
+    <pre><code>{ FHEM::Buienradar::BAR("name des buienradar device")}</code></pre>abgerufen werden.<br>
   </li>
   <li>
     <p>Ein von Google Charts generiertes Diagramm im <abbr>PNG</abbr>-Format, welcher mit</p>
-    <pre><code>  { FHEM::Buienradar::GChart("name des buienradar device")}</code></pre>
+    <pre><code>{ FHEM::Buienradar::GChart("name des buienradar device")}</code></pre>
     <p>abgerufen werden kann. <strong>Achtung!</strong> Dazu werden Daten an Google übertragen!</p>
   </li>
   <li>
     <p>Für <abbr>FTUI</abbr> werden die Daten im LogProxy-Format bereitgestellt:</p>
-    <pre><code>  { FHEM::Buienradar::LogProxy("name des buienradar device")}</code></pre>
+    <pre><code>{ FHEM::Buienradar::LogProxy("name des buienradar device")}</code></pre>
   </li>
 </ul>
 
@@ -1056,7 +1073,7 @@ sub Debugging {
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "author": [
         "Christoph Morrison <post@christoph-jeschke.de>"
     ],

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -903,72 +903,66 @@ sub Debugging {
 =begin html
 
 <p><span id="Buienradar"></span></p>
-<h2 id="buienradar">Buienradar</h2>
+<h2>Buienradar</h2>
 <p>Buienradar provides access to precipitation forecasts by the dutch service <a href="https://www.buienradar.nl">Buienradar.nl</a>.</p>
 <p><span id="Buienradardefine"></span></p>
-<h3 id="define">Define</h3>
+<h3>Define</h3>
 <pre><code>define &lt;devicename&gt; Buienradar [latitude] [longitude]</code></pre>
-<p><var>latitude</var> and <var>longitude</var> are facultative and will gathered from <var>global</var> if not set.<br>
-So the smallest possible definition is:</p>
+<p><var>latitude</var> and <var>longitude</var> are facultative and will gathered from <var>global</var> if not set. So the smallest possible definition is:</p>
 <pre><code>define &lt;devicename&gt; Buienradar</code></pre>
 <p><span id="Buienradarget"></span></p>
-<h3 id="get">Get</h3>
+<h3>Get</h3>
 <p><var>Get</var> will get you the following:</p>
 <ul>
-  <li><code>rainDuration</code> - predicted duration of the next precipitation in minutes.<br></li>
-  <li><code>startse</code> - next precipitation starts in <var>n</var> minutes. <strong>Obsolete!</strong><br></li>
-  <li><code>refresh</code> - get new data from Buienradar.nl.<br></li>
-  <li><code>version</code> - get current version of the Buienradar module.<br></li>
+  <li><code>rainDuration</code> - predicted duration of the next precipitation in minutes.</li>
+  <li><code>startse</code> - next precipitation starts in <var>n</var> minutes. <strong>Obsolete!</strong></li>
+  <li><code>refresh</code> - get new data from Buienradar.nl.</li>
+  <li><code>version</code> - get current version of the Buienradar module.</li>
   <li><code>testVal</code> - converts the gathered values from the old Buienradar <abbr>API</abbr> to mm/m². <strong>Obsolete!</strong></li>
 </ul>
 <p><span id="Buienradarreadings"></span></p>
-<h3 id="readings">Readings</h3>
+<h3>Readings</h3>
 <p>Buienradar provides several readings:</p>
 <ul>
-  <li><code>Begin</code> - Start of predicted precipitation in HH:MM format. If no precipitation is predicted, <var>unknown</var>.<br></li>
-  <li><code>Duration</code> - Duration of predicted precipitation in HH:MM Format.<br></li>
-  <li><code>End</code> - End of predicted precipitation in HH:MM format. If no precipitation is predicted, <var>unknown</var>.<br></li>
-  <li><code>rainAmount</code> - amount of predicted precipitation in mm/h or l/qm for the next 1 hour interval.<br></li>
-  <li><code>rainBegin</code> - starting time of the next precipitation, <var>unknown</var> if no precipitation is predicted.<br></li>
-  <li><code>raindEnd</code> - ending time of the next precipitation, <var>unknown</var> if no precipitation is predicted.<br></li>
-  <li><code>rainDataStart</code> - starting time of gathered data.<br></li>
-  <li><code>rainDataEnd</code> - ending time of gathered data.<br></li>
-  <li><code>rainDuration</code> - Duration of predicted precipitation in full time format.<br></li>
-  <li><code>rainDurationMin</code> - Duration of predicted precipitation in minutes.<br></li>
-  <li><code>rainLaMetric</code> - data formatted for a LaMetric device.<br></li>
-  <li><code>rainMax</code> - maximal amount of precipitation for <strong>any</strong> 5 minute interval of the gathered data in mm.<br></li>
-  <li><code>rainNow</code> - amount of precipitation for the <strong>current</strong> 5 minute interval in mm.<br></li>
-  <li><code>rainTotal</code> - total amount of precipition for the gathered data in mm.</li>
+  <li><code>rainAmount</code> - amount of predicted precipitation in mm/h for the next 5 minute interval.</li>
+  <li><code>rainBegin</code> - starting time of the next precipitation, <var>unknown</var> if no precipitation is predicted.</li>
+  <li><code>raindEnd</code> - ending time of the next precipitation, <var>unknown</var> if no precipitation is predicted.</li>
+  <li><code>rainDataStart</code> - starting time of gathered data.</li>
+  <li><code>rainDataEnd</code> - ending time of gathered data.</li>
+  <li><code>rainLaMetric</code> - data formatted for a LaMetric device.</li>
+  <li><code>rainMax</code> - maximal amount of precipitation for <strong>any</strong> 5 minute interval of the gathered data in mm/h.</li>
+  <li><code>rainNow</code> - amount of precipitation for the <strong>current</strong> 5 minute interval in mm/h.</li>
+  <li><code>rainTotal</code> - total amount of precipition for the gathered data in mm/h.</li>
 </ul>
 <p><span id="Buienradarattr"></span></p>
-<h3 id="attributes">Attributes</h3>
+<h3>Attributes</h3>
 <ul>
   <li>
-    <a name="disabled" id="disabled"></a> <code>disabled 1|0|on|off</code> - If <code>disabled</code> is set to <code>on or 1</code>, no further requests to Buienradar.nl will be performed. <code>off</code> reactivates the device, also if the attribute ist simply deleted.<br>
+    <a name="disabled" id="disabled"></a> <code>disabled on|off</code> - If <code>disabled</code> is set to <code>on</code>, no further requests to Buienradar.nl will be performed. <code>off</code> reactivates the device, also if the attribute ist simply deleted.
   </li>
   <li>
-    <a name="region" id="region"></a> <code>region nl|de</code> - Allowed values are <code>nl</code> (default value) and <code>de</code>. In some cases, especially in the south and east of Germany, <code>de</code> returns values at all.<br>
+    <a name="region" id="region"></a> <code>region nl|de</code> - Allowed values are <code>nl</code> (default value) and <code>de</code>. In some cases, especially in the south and east of Germany, <code>de</code> returns values at all.
   </li>
   <li>
-    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300|600</code> - Data update every <var>n</var> seconds. <strong>Attention!</strong> 10 seconds is a very aggressive value and should be chosen carefully, <abbr>e.g.</abbr> when troubleshooting. The default value is 120 seconds.
+    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300</code> - Data update every <var>n</var> seconds. <strong>Attention!</strong> 10 seconds is a very aggressive value and should be chosen carefully, <abbr>e.g.</abbr> when troubleshooting. The default value is 120 seconds.
   </li>
 </ul>
-<h3 id="visualisation">Visualisation</h3>
+<h3>Visualisation</h3>
 <p>Buienradar offers besides the usual view as device also the possibility to visualize the data as charts in different formats.</p>
 <ul>
   <li>
     <p>An HTML version that is displayed in the detail view by default and can be viewed with</p>
-    <pre><code>{ FHEM::Buienradar::HTML("buienradar device name")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::HTML("buienradar device name")}</code></pre>
     <p>can be retrieved.</p>
   </li>
   <li>
     <p>A chart generated by Google Charts in <abbr>PNG</abbr> format, which can be viewed with</p>
-    <pre><code>{ FHEM::Buienradar::GChart("buienradar device name")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::GChart("buienradar device name")}</code></pre>
     <p>can be retrieved. <strong>Caution!</strong> Please note that data is transferred to Google for this purpose!</p>
   </li>
   <li>
     <p><abbr>FTUI</abbr> is supported by the LogProxy format:</p>
-    <pre><code>{ FHEM::Buienradar::LogProxy("buienradar device name")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::LogProxy("buienradar device name")}</code></pre>
   </li>
 </ul>
 
@@ -977,76 +971,65 @@ So the smallest possible definition is:</p>
 =begin html_DE
 
 <p><span id="Buienradar"></span></p>
-<h2 id="buienradar">Buienradar</h2>
-<p>Das Buienradar-Modul bindet die Niederschlagsvorhersagedaten der freien <abbr title="Application Program Interface">API</abbr><br>
-von <a href="https://www.buienradar.nl">Buienradar.nl</a> an.</p>
+<h2>Buienradar</h2>
+<p>Das Buienradar-Modul bindet die Niederschlagsvorhersagedaten der freien <abbr title="Application Program Interface">API</abbr> von <a href="https://www.buienradar.nl">Buienradar.nl</a> an.</p>
 <p><span id="Buienradardefine"></span></p>
-<h3 id="define">Define</h3>
+<h3>Define</h3>
 <pre><code>define &lt;devicename&gt; Buienradar [latitude] [longitude]</code></pre>
-<p>Die Werte für latitude und longitude sind optional und werden, wenn nicht explizit angegeben, von <var>global</var> bezogen.<br>
-Die minimalste Definition lautet demnach:</p>
+<p>Die Werte für latitude und longitude sind optional und werden, wenn nicht explizit angegeben, von <var>global</var> bezogen. Die minimalste Definition lautet demnach:</p>
 <pre><code>define &lt;devicename&gt; Buienradar</code></pre>
 <p><span id="Buienradarget"></span></p>
-<h3 id="get">Get</h3>
+<h3>Get</h3>
 <p>Aktuell lassen sich folgende Daten mit einem Get-Aufruf beziehen:</p>
 <ul>
-  <li><code>rainDuration</code> - Die voraussichtliche Dauer des nächsten Niederschlags in Minuten.<br></li>
-  <li><code>startse</code> - Der nächste Niederschlag beginnt in <var>n</var> Minuten. <strong>Obsolet!</strong><br></li>
-  <li><code>refresh</code> - Neue Daten abfragen.<br></li>
-  <li><code>version</code> - Aktuelle Version abfragen.<br></li>
+  <li><code>rainDuration</code> - Die voraussichtliche Dauer des nächsten Niederschlags in Minuten.</li>
+  <li><code>startse</code> - Der nächste Niederschlag beginnt in <var>n</var> Minuten. <strong>Obsolet!</strong></li>
+  <li><code>refresh</code> - Neue Daten abfragen.</li>
+  <li><code>version</code> - Aktuelle Version abfragen.</li>
   <li><code>testVal</code> - Rechnet einen Buienradar-Wert zu Testzwecken in mm/m² um. Dies war für die alte <abbr>API</abbr> von Buienradar.nl nötig. <strong>Obsolet!</strong></li>
 </ul>
 <p><span id="Buienradarreadings"></span></p>
-<h3 id="readings">Readings</h3>
+<h3>Readings</h3>
 <p>Aktuell liefert Buienradar folgende Readings:</p>
 <ul>
-  <li><code>Begin</code> - Beginn des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
-  <li><code>Duration</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in HH:MM Format.<br></li>
-  <li><code>End</code> - Ende des nächsten Niederschlag in HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
-  <li><code>rainAmount</code> - Menge des gemeldeten Niederschlags in mm/h (= l/qm) für die nächste Stunde.<br></li>
-  <li><code>rainBegin</code> - Beginn des nächsten Niederschlag in YY-mm-dd HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
-  <li><code>raindEnd</code> - Ende des nächsten Niederschlag in YY-mm-dd HH:MM format. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.<br></li>
-  <li><code>rainDataStart</code> - Zeitlicher Beginn der gelieferten Niederschlagsdaten.<br></li>
-  <li><code>rainDataEnd</code> - Zeitliches Ende der gelieferten Niederschlagsdaten.<br></li>
-  <li><code>rainDuration</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in YY-mm-dd HH:MM format.<br></li>
-  <li><code>rainDurationMin</code> - Zeitliche Dauer der gelieferten Niederschlagsdaten in Minuten.<br></li>
-  <li><code>rainLaMetric</code> - Aufbereitete Daten für LaMetric-Devices.<br></li>
-  <li><code>rainMax</code> - Die maximale Niederschlagsmenge in mm für ein 5 Min. Intervall auf Basis der vorliegenden Daten.<br></li>
-  <li><code>rainNow</code> - Die vorhergesagte Niederschlagsmenge für das aktuelle 5 Min. Intervall in mm.<br></li>
-  <li><code>rainTotal</code> - Die gesamte vorhergesagte Niederschlagsmenge in mm</li>
+  <li><code>rainAmount</code> - Menge des gemeldeten Niederschlags in mm/h für den nächsten 5-Minuten-Intervall.</li>
+  <li><code>rainBegin</code> - Beginn des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
+  <li><code>raindEnd</code> - Ende des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.</li>
+  <li><code>rainDataStart</code> - Zeitlicher Beginn der gelieferten Niederschlagsdaten.</li>
+  <li><code>rainDataEnd</code> - Zeitliches Ende der gelieferten Niederschlagsdaten.</li>
+  <li><code>rainLaMetric</code> - Aufbereitete Daten für LaMetric-Devices.</li>
+  <li><code>rainMax</code> - Die maximale Niederschlagsmenge in mm/h für ein 5 Min. Intervall auf Basis der vorliegenden Daten.</li>
+  <li><code>rainNow</code> - Die vorhergesagte Niederschlagsmenge für das aktuelle 5 Min. Intervall in mm/h.</li>
+  <li><code>rainTotal</code> - Die gesamte vorhergesagte Niederschlagsmenge in mm/h</li>
 </ul>
 <p><span id="Buienradarattr"></span></p>
-<h3 id="attribute">Attribute</h3>
+<h3>Attribute</h3>
 <ul>
   <li>
-    <a name="disabled" id="disabled"></a> <code>disabled 1|0|on|off</code> - Wenn <code>disabled</code> auf <code>on oder 1</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.<br>
+    <a name="disabled" id="disabled"></a> <code>disabled on|off</code> - Wenn <code>disabled</code> auf <code>on</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.
   </li>
   <li>
-    <a name="region" id="region"></a> <code>region nl|de</code> - Erlaubte Werte sind <code>nl</code> (Standardwert) und <code>de</code>. In einigen Fällen, insbesondere im Süden und Osten Deutschlands, liefert <code>de</code> überhaupt Werte.<br>
+    <a name="region" id="region"></a> <code>region nl|de</code> - Erlaubte Werte sind <code>nl</code> (Standardwert) und <code>de</code>. In einigen Fällen, insbesondere im Süden und Osten Deutschlands, liefert <code>de</code> überhaupt Werte.
   </li>
   <li>
-    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300|600</code> - Aktualisierung der Daten alle <var>n</var> Sekunden. <strong>Achtung!</strong> 10 Sekunden ist ein sehr aggressiver Wert und sollte mit Bedacht gewählt werden, <abbr>z.B.</abbr> bei der Fehlersuche. Standardwert sind 120 Sekunden.
+    <a name="interval" id="interval"></a> <code>interval 10|60|120|180|240|300</code> - Aktualisierung der Daten alle <var>n</var> Sekunden. <strong>Achtung!</strong> 10 Sekunden ist ein sehr aggressiver Wert und sollte mit Bedacht gewählt werden, <abbr>z.B.</abbr> bei der Fehlersuche. Standardwert sind 120 Sekunden.
   </li>
 </ul>
-<h3 id="visualisierungen">Visualisierungen</h3>
+<h3>Visualisierungen</h3>
 <p>Buienradar bietet neben der üblichen Ansicht als Device auch die Möglichkeit, die Daten als Charts in verschiedenen Formaten zu visualisieren.</p>
 <ul>
   <li>
     <p>Eine HTML-Version die in der Detailansicht standardmäßig eingeblendet wird und mit</p>
-    <pre><code>{ FHEM::Buienradar::HTML("name des buienradar device")}</code></pre>abgerufen werden.<br>
-  </li>
-  <li>
-    <p>Eine HTML-"BAR"-Version, diese gibt einen HTML Balken mit einer farblichen Representation der Regenmenge aus und kann mit</p>
-    <pre><code>{ FHEM::Buienradar::BAR("name des buienradar device")}</code></pre>abgerufen werden.<br>
+    <pre><code>  { FHEM::Buienradar::HTML("name des buienradar device")}</code></pre>abgerufen werden.
   </li>
   <li>
     <p>Ein von Google Charts generiertes Diagramm im <abbr>PNG</abbr>-Format, welcher mit</p>
-    <pre><code>{ FHEM::Buienradar::GChart("name des buienradar device")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::GChart("name des buienradar device")}</code></pre>
     <p>abgerufen werden kann. <strong>Achtung!</strong> Dazu werden Daten an Google übertragen!</p>
   </li>
   <li>
     <p>Für <abbr>FTUI</abbr> werden die Daten im LogProxy-Format bereitgestellt:</p>
-    <pre><code>{ FHEM::Buienradar::LogProxy("name des buienradar device")}</code></pre>
+    <pre><code>  { FHEM::Buienradar::LogProxy("name des buienradar device")}</code></pre>
   </li>
 </ul>
 
@@ -1073,7 +1056,7 @@ Die minimalste Definition lautet demnach:</p>
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "2.2.5",
+    "version": "2.2.4",
     "author": [
         "Christoph Morrison <post@christoph-jeschke.de>"
     ],

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,2 +1,2 @@
 DEL ./FHEM/59_Buienradar.pm
-UPD 2019-08-09_11:32:32 39736 FHEM/59_Buienradar.pm
+UPD 2019-08-12_13:43:30 39753 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,2 +1,2 @@
 DEL ./FHEM/59_Buienradar.pm
-UPD 2019-08-12_13:43:30 39753 FHEM/59_Buienradar.pm
+UPD 2019-08-12_18:11:34 39758 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,2 +1,2 @@
 DEL ./FHEM/59_Buienradar.pm
-UPD 2019-08-09_10:39:30 38490 FHEM/59_Buienradar.pm
+UPD 2019-08-09_10:57:49 39157 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,2 +1,2 @@
 DEL ./FHEM/59_Buienradar.pm
-UPD 2019-08-09_09:50:42 38452 FHEM/59_Buienradar.pm
+UPD 2019-08-09_10:39:30 38490 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,2 +1,2 @@
 DEL ./FHEM/59_Buienradar.pm
-UPD 2019-08-08_07:35:54 35573 FHEM/59_Buienradar.pm
+UPD 2019-08-09_09:50:42 38452 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,2 +1,2 @@
 DEL ./FHEM/59_Buienradar.pm
-UPD 2019-08-09_11:05:45 39091 FHEM/59_Buienradar.pm
+UPD 2019-08-09_11:18:38 39090 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,2 +1,2 @@
 DEL ./FHEM/59_Buienradar.pm
-UPD 2019-08-05_15:17:51 34568 FHEM/59_Buienradar.pm
+UPD 2019-08-08_07:35:54 35573 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,2 +1,2 @@
 DEL ./FHEM/59_Buienradar.pm
-UPD 2019-08-12_18:11:34 39758 FHEM/59_Buienradar.pm
+UPD 2019-08-18_20:15:43 39795 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,2 +1,2 @@
 DEL ./FHEM/59_Buienradar.pm
-UPD 2019-08-09_10:57:49 39157 FHEM/59_Buienradar.pm
+UPD 2019-08-09_11:05:45 39091 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,2 +1,2 @@
 DEL ./FHEM/59_Buienradar.pm
-UPD 2019-08-09_11:18:38 39090 FHEM/59_Buienradar.pm
+UPD 2019-08-09_11:32:32 39736 FHEM/59_Buienradar.pm

--- a/meta.json
+++ b/meta.json
@@ -16,7 +16,7 @@
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "2.2.3",
+    "version": "2.2.4",
     "author": [
         "Christoph Morrison <post@christoph-jeschke.de>"
     ],

--- a/meta.json
+++ b/meta.json
@@ -16,7 +16,7 @@
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "author": [
         "Christoph Morrison <post@christoph-jeschke.de>"
     ],


### PR DESCRIPTION
So, diesmal mit funktionierender Version von inoma.

2.2.4 https://forum.fhem.de/index.php/topic,102497.msg965120.html#msg965120
> Hallo Christoph,
> anbei ein Patch, wo ich folgendes mal geändert habe. Spart Dir evtl. Arbeit.
> - rainNow ist auf das erste Intervall gesetzt
> - rainAmount ist die Regen Menge in der erste Stunde, also l/qm 
> - rainEnd ist korrigiert, falls es mehrer RegenIntervalle gibt (also zwischendurch mal kein Regen). Für den Fall das es am Ende auch noch regnet, ist rainEnd auf das letzte Interval gesetzt
> - Rainduration wird berechnet, einmal als HH:MM und auch in Minuten
> - Ich hatte gesehen das die Intervalle manchmal vor der jetzigen Zeit anfangen, updates also nur für Zeiträume > TimeNow()
> - Formatierung auf %.1f geändert (alle Webseiten geben auch nur Regen in mm auf 1 Stelle genau aus)
> - Versionsnummer nur zur Unterscheidung auf 2.2.4 geändert

2.2.5 https://forum.fhem.de/index.php/topic,102497.msg965541.html#msg965541

> Hallo Christoph,
> ich habe nochmal ein bischen gebastelt:
> Anbei ein weiterer Patch, wo ich folgendes mal geändert habe.
> - Doku angepasst sowohl in Deutsch als auch Englisch
> - Support für HTML "BAR" Chart, wie auch bei RainTMC, aufruf mit { FHEM::Buienradar::BAR("Name des Buienradar device")}
> - Readings 'Start' und 'Ende' -> 'Begin' und 'End'
> - zusätzliches Interval 600
> - disable 0/1 wählbar
> - Einige kleine Änderungen/Anpassungen
> - Versionsnummer nur zur Unterscheidung auf 2.2.5 geändert
> 
> Bitte nicht falsch verstehen, ich möchte einfach nur beitragen, anstatt einfach immer nur nach Änderungen zu fragen.
> 
> Für das "BAR" Chart, verwendet das RainTMC modul $a->{ColorAsRGB}, ich habe damit aber immer eine Fehlermeldung bekommen. Wel das nicht funktioniert hat, habe ich jetzt stattdessen eine Sub raus gemacht, also in Zeile 752 und 757 eine Sub myPrecip2RGB($a) eingebaut. Die Sub ist im modul. Wenn Du Dir das mal angucken magst?
> 
> Danke und Beste Grüsse