### PR TITLE
Version 3.0.6

### DIFF
--- a/CHANGED
+++ b/CHANGED
@@ -1,6 +1,6 @@
-Last Buienradar updates (14.04.2020)
-  147f165 13.04.2020 23:52 #40 reenable Timer() when disabled attribute ist just deleted
-  540bcde 13.04.2020 23:50 #41 fix an issue with Debugging() only responding with @_
-  b2fe8be 13.04.2020 23:48 #21 if a location is out of coverage for the selected region, please show proper error message instead of simply a HTTP/404
-  642f8ec 13.04.2020 23:12 #39 fixed not interpolated return value for Get()
-  62321bb 13.04.2020 23:09 #38 fixed no result from get rainDuration
+Last Buienradar updates (24.04.2020)
+  aac4bda 24.04.2020 18:58 #108 ignore unused capturing groups
+  1f30d4a 22.04.2020 11:01 #93 refactored the bogus `define` error message, don't I18N it
+  e397219 22.04.2020 10:52 #102 #98 beautified the HTML charts markup, I18N for the labels there
+  d9c0c17 21.04.2020 12:04 #87 removed globally used device name
+  90a60e6 21.04.2020 06:55 #46 resolved the version string finally

--- a/CommandRef.de.md
+++ b/CommandRef.de.md
@@ -92,15 +92,19 @@ Buienradar bietet neben der üblichen Ansicht als Device auch die Möglichkeit, 
         
 * Für eine reine Text-Ausgabe der Daten als Graph, kann
 
-        { FHEM::Buienradar::TextChart("name des buienradar device")}
+        { FHEM::Buienradar::TextChart(q{name des buienradar device}, q{verwendetes zeichen})}
         
-    verwendet werden. Ausgegeben wird ein für jeden Datensatz eine Zeile im Muster
+    verwendet werden. Das `verwendete zeichen` ist optional und mit `=` vorbelegt. Ausgegeben wird beispielsweise für den Aufruf
     
-        22:25 |   0.060 | =
-        22:30 |   0.370 | ====
-        22:35 |   0.650 | =======
+        { FHEM::Buienradar::TextChart(q{buienradar_test}, q{#}) }
         
-    wobei für jede 0.1 mm/h Niederschlag ein ``=`` ausgegeben wird, maximal jedoch 50 Einheiten. Mehr werden mit einem
-    ``>`` abgekürzt.
+     für jeden Datensatz eine Zeile im Muster
     
-        23:00 |  11.800 | ==================================================>
+        22:25 |   0.060 | #
+        22:30 |   0.370 | ###
+        22:35 |   0.650 | #######
+        
+    wobei für jede 0.1 mm/h Niederschlag das `#` verwendet wird, maximal jedoch 50 Einheiten.
+    Mehr werden mit einem `>` abgekürzt.
+    
+        23:00 |  11.800 | ##################################################>

--- a/CommandRef.en.md
+++ b/CommandRef.en.md
@@ -88,17 +88,23 @@ Buienradar offers besides the usual view as device also the possibility to visua
 
         { FHEM::Buienradar::LogProxy("buienradar device name")}
         
-* A plain text representation can be display by
+* A plain text representation can be displayed with
 
-        { FHEM::Buienradar::TextChart("buienradar device name")}
+        { FHEM::Buienradar::TextChart(q{buienradar device name}, q{bar chart character})}
         
-    Every line represents a record of the whole set in a format like
+    The bar chart character is optional and defaults to `=`.
     
-        22:25 |   0.060 | =
-        22:30 |   0.370 | ====
-        22:35 |   0.650 | =======
+    Every line represents a record of the whole set, i.e. if called by
+    
+        { FHEM::Buienradar::TextChart(q{buienradar_test_device}, q{#})}
+    
+    the result will look similar to
+    
+        22:25 |   0.060 | #
+        22:30 |   0.370 | ####
+        22:35 |   0.650 | #######
         
-    For every 0.1 mm/h precipitation a ``=`` is displayed, but the output is capped to 50 units. If more than 50 units
-    would be display, the bar is appended with a ``>``.
+    For every 0.1 mm/h precipitation a ``#`` is displayed, but the output is capped to 50 units. If
+    more than 50 units would be display, the bar is truncated and appended with a ``>``.
     
-        23:00 |  11.800 | ==================================================>
+        23:00 |  11.800 | ##################################################>

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -184,11 +184,11 @@ sub Initialize {
     my ($hash) = @_;
 
     $hash->{DefFn}       = \&FHEM::Buienradar::Define;
-    $hash->{UndefFn}     = 'FHEM::Buienradar::Undefine';
-    $hash->{GetFn}       = 'FHEM::Buienradar::Get';
-    $hash->{SetFn}       = 'FHEM::Buienradar::Set';
-    $hash->{AttrFn}      = 'FHEM::Buienradar::Attr';
-    $hash->{FW_detailFn} = 'FHEM::Buienradar::Detail';
+    $hash->{UndefFn}     = \&FHEM::Buienradar::Undefine;
+    $hash->{GetFn}       = \&FHEM::Buienradar::Get;
+    $hash->{SetFn}       = \&FHEM::Buienradar::Set;
+    $hash->{AttrFn}      = \&FHEM::Buienradar::Attr;
+    $hash->{FW_detailFn} = \&FHEM::Buienradar::Detail;
     $hash->{AttrList}    = join(q{ },
         (
             'disabled:on,off',
@@ -196,7 +196,6 @@ sub Initialize {
             'interval:10,60,120,180,240,300'
         )
     ) . qq[ $::readingFnAttributes ];
-    $hash->{'.PNG'} = q{};
     $hash->{REGION} = $default_region;
 
     return;
@@ -222,7 +221,7 @@ sub Detail {
 #####################################
 sub Undefine {
     my ( $hash, $arg ) = @_;
-    ::RemoveInternalTimer( $hash, 'FHEM::Buienradar::Timer' );
+    ::RemoveInternalTimer( $hash, \&FHEM::Buienradar::Timer );
     return;
 }
 
@@ -354,7 +353,7 @@ sub Attr {
                         if $attribute_value !~ /^(on|off|0|1)$/;
 
                     if ($attribute_value =~ /(on|1)/) {
-                        ::RemoveInternalTimer( $hash, 'FHEM::Buienradar::Timer' );
+                        ::RemoveInternalTimer( $hash,\&FHEM::Buienradar::Timer );
                         $::attr{$device_name}{'disable'} = 1;
                         $hash->{NEXTUPDATE} = undef;
                         $hash->{STATE} = 'inactive';
@@ -478,13 +477,13 @@ sub Timer {
     my ($hash) = @_;
     my $nextupdate = 0;
 
-    ::RemoveInternalTimer( $hash, 'FHEM::Buienradar::Timer' );
+    ::RemoveInternalTimer( $hash, \&FHEM::Buienradar::Timer );
 
     $nextupdate = int( time() + $hash->{INTERVAL} );
     $hash->{NEXTUPDATE} = ::FmtDateTime($nextupdate);
     RequestUpdate($hash);
 
-    ::InternalTimer( $nextupdate, 'FHEM::Buienradar::Timer', $hash );
+    ::InternalTimer( $nextupdate, \&FHEM::Buienradar::Timer, $hash );
 
     return 1;
 }

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -477,8 +477,10 @@ sub Define {
     $global_hash = $hash;
 
     my @a = split( '[ \t][ \t]*', $def );
+    my $name = $a[0];
     my $latitude;
     my $longitude;
+    my $language = lc ::AttrVal('global', 'language', 'DE');
 
     if ( ( int(@a) == 2 ) && ( ::AttrVal( 'global', 'latitude', -255 ) != -255 ) )
     {
@@ -490,13 +492,12 @@ sub Define {
         $longitude = $a[3];
     }
     else {
-        # @todo this looks bogus and unnecessary
-        return int(@a) . q{Syntax: define <name> Buienradar [<latitude> <longitude>]};
+        return Error($name, q{Syntax: define <name> Buienradar [<latitude> <longitude>]})
     }
 
     ::readingsSingleUpdate($hash, 'state', 'Initialized', 1);
 
-    my $name = $a[0];
+
     $hash->{NAME}       = $name;
     $hash->{VERSION}    = $version;
     $hash->{INTERVAL}   = $default_interval;
@@ -504,7 +505,7 @@ sub Define {
     $hash->{LONGITUDE}  = $longitude;
     $hash->{URL}        = undef;
     # get language for language dependend legend
-    $language = lc ::AttrVal('global', 'language', 'DE');
+
 
     ::readingsBeginUpdate($hash);
         ::readingsBulkUpdate( $hash, 'rainNow', 'unknown' );

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -47,7 +47,7 @@ use English;
 use Storable;
 use GPUtils qw(GP_Import GP_Export);
 use experimental qw( switch );
-use v5.10;
+use 5.10;
 use Readonly;
 
 =pod

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -353,7 +353,7 @@ sub Attr {
             given ($command) {
                 when ('set') {
                     return qq[${attribute_value} is not a valid value for disabled. Only 'on' or 'off' are allowed!]
-                        if $attribute_value !~ /^(?:on | off | 0 |1 )$/x;
+                        if $attribute_value !~ /^(?: on | off | 0 | 1 )$/x;
 
                     if ($attribute_value =~ /(on|1)/x) {
                         ::RemoveInternalTimer( $hash,\&FHEM::Buienradar::Timer );

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -762,20 +762,32 @@ sub TextChart {
 
     my %storedData = %{ Storable::thaw($hash->{'.SERIALIZED'}) };
 
+    my ($time, $precip, $bar);
     my $data = join qq{\n}, map {
-        my ($time, $precip, $bar) = (
-            POSIX::strftime('%H:%M', localtime $storedData{$_}{'start'}),
-            sprintf('% 7.3f', $storedData{$_}{'precipitation'}),
-            (
-                ($storedData{$_}{'precipitation'} < 50)
-                    ? $bar_character x  POSIX::lround(abs($storedData{$_}{'precipitation'} * 10))
-                    : ($bar_character x  50) . q{>}
-            ),
-        );
-        qq[$time | $precip | $bar]
+        join ' | ', ShowTextChartBar(%{ Storable::thaw($hash->{'.SERIALIZED'}) }, $bar_character);
     } sort keys %storedData;
 
     return $data;
+}
+
+=pod
+    Build the char bar for the text chart
+=cut
+sub ShowTextChartBar {
+    my %storedData = shift;
+    my $bar_character = shift;
+
+    my ($time, $precip, $bar) = (
+        POSIX::strftime('%H:%M', localtime $storedData{$_}{'start'}),
+        sprintf('% 7.3f', $storedData{$_}{'precipitation'}),
+        (
+            ($storedData{$_}{'precipitation'} < 50)
+                ? $bar_character x  POSIX::lround(abs($storedData{$_}{'precipitation'} * 10))
+                : ($bar_character x  50) . q{>}
+        ),
+    );
+
+    return ($time, $precip, $bar);
 }
 
 sub ParseHttpResponse {

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -353,7 +353,7 @@ sub Attr {
             given ($command) {
                 when ('set') {
                     return qq[${attribute_value} is not a valid value for disabled. Only 'on' or 'off' are allowed!]
-                        if $attribute_value !~ /^(on|off|0|1)$/x;
+                        if $attribute_value !~ /^(?:on | off | 0 |1 )$/x;
 
                     if ($attribute_value =~ /(on|1)/x) {
                         ::RemoveInternalTimer( $hash,\&FHEM::Buienradar::Timer );

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -62,7 +62,7 @@ Readonly our $default_bar_character => q{=};
 =pod
     Translations
 =cut
-Readonly our %Translations => (
+Readonly my %Translations => (
     'GChart' => {
         'hAxis'  => {
             'de' => 'Uhrzeit',
@@ -96,10 +96,10 @@ Readonly our %Translations => (
 =pod
     Global variables
 =cut
-our $device_name;
-our @errors;
-our $global_hash;
-our $language;
+my $device_name;
+my @errors;
+my $global_hash;
+my $language;
 
 
 GP_Export(
@@ -333,6 +333,7 @@ sub Get {
 
 sub Attr {
     my ($command, $device_name, $attribute_name, $attribute_value) = @_;
+
     my $hash = $::defs{$device_name};
     
     FHEM::Buienradar::Debugging(Dumper({
@@ -402,7 +403,7 @@ sub Attr {
                 }
 
                 when ('del') {
-                    $hash->{INTERVAL} = $FHEM::Buienradar::default_interval;
+                    $hash->{INTERVAL} = $default_interval;
                 }
             }
 
@@ -445,12 +446,12 @@ sub Define {
     $device_name = $name;
 
     $hash->{VERSION}    = $version;
-    $hash->{INTERVAL}   = $FHEM::Buienradar::default_interval;
+    $hash->{INTERVAL}   = $default_interval;
     $hash->{LATITUDE}   = $latitude;
     $hash->{LONGITUDE}  = $longitude;
     $hash->{URL}        = undef;
     # get language for language dependend legend
-    $FHEM::Buienradar::language = lc ::AttrVal('global', 'language', 'DE');
+    $language = lc ::AttrVal('global', 'language', 'DE');
 
     ::readingsBeginUpdate($hash);
         ::readingsBulkUpdate( $hash, 'rainNow', 'unknown' );
@@ -585,14 +586,14 @@ sub GChart {
     } sort keys %storedData;
 
     # create data for the GChart
-    my $hAxis   = $FHEM::Buienradar::Translations{'GChart'}{'hAxis'}{$language};
-    my $vAxis   = $FHEM::Buienradar::Translations{'GChart'}{'vAxis'}{$language};
+    my $hAxis   = $Translations{'GChart'}{'hAxis'}{$language};
+    my $vAxis   = $Translations{'GChart'}{'vAxis'}{$language};
     my $title   = sprintf(
-        $FHEM::Buienradar::Translations{'GChart'}{'title'}{$language},
+        $Translations{'GChart'}{'title'}{$language},
         $hash->{LATITUDE},
         $hash->{LONGITUDE}
     );
-    my $legend  = $FHEM::Buienradar::Translations{'GChart'}{'legend'}{$language};
+    my $legend  = $Translations{'GChart'}{'legend'}{$language};
 
     return <<'CHART'
 <div id='chart_${name}'; style='width:100%; height:100%'></div>
@@ -633,6 +634,7 @@ sub GChart {
 
 CHART
 }
+
 =over 1
 
 =item C<FHEM::Buienradar::LogProxy>
@@ -949,7 +951,7 @@ sub ResetResult {
 sub Debugging {
     local $OFS = qq{\n};
     ::Debug(join($OFS, (qq{[$FHEM::Buienradar::device_name]}, qq{@_}))) if (
-        int(::AttrVal(q{global}, q{verbose}, 0)) >= $FHEM::Buienradar::debugging_min_verbose
+        int(::AttrVal(q{global}, q{verbose}, 0)) >= $debugging_min_verbose
         or  int(::AttrVal($device_name, q{debug}, 0)) == 1
     );
     return;

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -355,7 +355,7 @@ sub Attr {
                     return qq[${attribute_value} is not a valid value for disabled. Only 'on' or 'off' are allowed!]
                         if $attribute_value !~ /^(?: on | off | 0 | 1 )$/x;
 
-                    if ($attribute_value =~ /(on|1)/x) {
+                    if ($attribute_value =~ /(?: on | 1)/x) {
                         ::RemoveInternalTimer( $hash,\&FHEM::Buienradar::Timer );
                         $::attr{$device_name}{'disable'} = 1;
                         $hash->{NEXTUPDATE} = undef;

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -595,7 +595,7 @@ sub GChart {
     );
     my $legend  = $Translations{'GChart'}{'legend'}{$language};
 
-    return <<'CHART'
+    return <<"CHART"
 <div id='chart_${name}'; style='width:100%; height:100%'></div>
 <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>
 <script type='text/javascript'>

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -79,11 +79,15 @@ Readonly our %Translations => (
             'en' => 'Precipitation',
         },
     },
-    'Set'    => {
+    'Attr'    => {
         'interval' => {
-            'de'    =>  'ist kein valider Wert für den Intervall. Einzig 10, 60, 120, 180, 240 oder 300 sind erlaubt!',
-            'en'    =>  'is no valid value for interval. Only 10, 60, 120, 180, 240 or 300 are allowed!',
+            'de' => 'ist kein valider Wert für den Intervall. Einzig 10, 60, 120, 180, 240 oder 300 sind erlaubt!',
+            'en' => 'is no valid value for interval. Only 10, 60, 120, 180, 240 or 300 are allowed!',
         },
+        'region'   => {
+            'de' => q{ist kein valider Wert für die Region. Einzig 'de' oder 'nl' werden unterstützt!},
+            'en' => q{is no valid value for region. Only 'de' or 'nl' are allowed!},
+        }
     },
 );
 
@@ -330,7 +334,7 @@ sub Get {
 sub Attr {
     my ($command, $device_name, $attribute_name, $attribute_value) = @_;
     my $hash = $::defs{$device_name};
-
+    
     FHEM::Buienradar::Debugging(Dumper({
         command     =>  $command,
         device      =>  $device_name,
@@ -371,7 +375,7 @@ sub Attr {
         }
 
         when ('region') {
-            return qq[${attribute_value} is no valid value for region. Only 'de' or 'nl' are allowed!]
+            return Error(qq[${attribute_value} ${FHEM::Buienradar::Translations{'Attr'}{'region'}{$language}}])
                 if $attribute_value !~ /^(de|nl)$/ and $command eq 'set';
 
             given ($command) {
@@ -389,7 +393,7 @@ sub Attr {
         }
 
         when ('interval') {
-            return FHEM::Buienradar::Error(qq[${attribute_value} ${FHEM::Buienradar::Translations{'Set'}{'interval'}{$language}}])
+            return FHEM::Buienradar::Error(qq[${attribute_value} ${FHEM::Buienradar::Translations{'Attr'}{'interval'}{$language}}])
                 if $attribute_value !~ /^(10|60|120|180|240|300)$/ and $command eq 'set';
 
             given ($command) {

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -33,7 +33,10 @@
 
 =cut
 
-package FHEM::Buienradar;
+# @todo
+# ATM, it's not possible to comply to this Perl::Critic rule, because
+# the current state of the FHEM API does require this bogus XX_Name.pm convention
+package FHEM::Buienradar;   ## no critic (RequireFilenameMatchesPackage)
 
 use strict;
 use warnings;

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -110,18 +110,20 @@ GP_Export(
 
 # try to use JSON::MaybeXS wrapper
 #   for chance of better performance + open code
-eval {
+my $eval_return;
+
+$eval_return = eval {
     require JSON::MaybeXS;
     import JSON::MaybeXS qw( decode_json encode_json );
     1;
 };
 
-if ($@) {
+if (!$eval_return) {
     local $@ = undef;
 
     # try to use JSON wrapper
     #   for chance of better performance
-    eval {
+    $eval_return = eval {
 
         # JSON preference order
         local $ENV{PERL_JSON_BACKEND} =
@@ -133,40 +135,40 @@ if ($@) {
         1;
     };
 
-    if ($@) {
+    if (!$eval_return) {
         local $@ = undef;
 
         # In rare cases, Cpanel::JSON::XS may
         #   be installed but JSON|JSON::MaybeXS not ...
-        eval {
+        $eval_return = eval {
             require Cpanel::JSON::XS;
             import Cpanel::JSON::XS qw(decode_json encode_json);
             1;
         };
 
-        if ($@) {
+        if (!$eval_return) {
             local $@ = undef;
 
             # In rare cases, JSON::XS may
             #   be installed but JSON not ...
-            eval {
+            $eval_return = eval {
                 require JSON::XS;
                 import JSON::XS qw(decode_json encode_json);
                 1;
             };
 
-            if ($@) {
+            if (!$eval_return) {
                 local $@ = undef;
 
                 # Fallback to built-in JSON which SHOULD
                 #   be available since 5.014 ...
-                eval {
+                $eval_return = eval {
                     require JSON::PP;
                     import JSON::PP qw(decode_json encode_json);
                     1;
                 };
 
-                if ($@) {
+                if (!$eval_return) {
                     local $@ = undef;
 
                     # Fallback to JSON::backportPP in really rare cases

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -975,7 +975,7 @@ sub ResetResult {
 
 sub Debugging {
     local $OFS = qq{\n};
-    ::Debug(join($OFS, (qq{[$FHEM::Buienradar::device_name]}, qq{@_}))) if (
+    ::Debug(join($OFS, (qq{[$device_name]}, qq{@_}))) if (
         int(::AttrVal(q{global}, q{verbose}, 0)) >= $debugging_min_verbose
         or  int(::AttrVal($device_name, q{debug}, 0)) == 1
     );

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -50,7 +50,7 @@ use English;
 use Storable;
 use GPUtils qw(GP_Import GP_Export);
 use experimental qw( switch );
-use 5.10.0;
+use 5.010;                                  # we do not want perl be older than from 2007
 use Readonly;
 
 =pod

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -284,6 +284,7 @@ sub timediff2str {
     );
 }
 
+## no critic (ProhibitPackageVars)
 =pod
 
 @todo
@@ -292,6 +293,7 @@ Should be fixed if possible!
 
 =cut
 sub GetHash {
+
     my $name = shift;
     return $::defs{$name};
 }
@@ -321,6 +323,7 @@ sub Enable {
     $::attr{$name}{'disable'} = 0;
     return;
 }
+## use critic
 
 ###################################
 sub Set {

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -397,7 +397,7 @@ sub Attr {
 
         when ('interval') {
             return FHEM::Buienradar::Error(qq[${attribute_value} ${FHEM::Buienradar::Translations{'Attr'}{'interval'}{$language}}])
-                if $attribute_value !~ /^(10|60|120|180|240|300)$/x and $command eq 'set';
+                if $attribute_value !~ /^(?: 10 | 60 | 120 | 180 | 240 | 300 )$/x and $command eq 'set';
 
             given ($command) {
                 when ('set') {

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -66,6 +66,16 @@ Readonly our $default_bar_character => q{=};
     Translations
 =cut
 Readonly my %Translations => (
+    'HTMLChart' => {
+        'title'      => {
+            'de' => q{Niederschlagsdiagramm},
+            'en' => q{Precipitation chart}
+        },
+        'data_start' => {
+            'de' => q{Datenbeginn um},
+            'en' => q{Data start at},
+        }
+    },
     'GChart' => {
         'hAxis'  => {
             'de' => 'Uhrzeit',
@@ -561,10 +571,10 @@ sub HTML {
     my $hash = GetHash($name);
     my @values = split /:/x, ::ReadingsVal($name, 'rainData', '0:0');
 
-    my $as_html = <<'END_MESSAGE';
+    my $as_html = <<'CSS_STYLE';
 <style>
 
-.BRchart div {
+.buienradar .htmlchart div {
   font: 10px sans-serif;
   background-color: steelblue;
   text-align: right;
@@ -574,26 +584,27 @@ sub HTML {
 }
  
 </style>
-<div class='BRchart'>
-END_MESSAGE
+<div class='buienradar'>
+CSS_STYLE
 
-    # @todo the html looks terribly ugly
-    $as_html .= qq[<BR>Niederschlag (<a href=./fhem?detail=$name>$name</a>)<BR>];
-
-    $as_html .= ::ReadingsVal( $name, 'rainDataStart', 'unknown' ) . '<BR>';
+    $as_html .= qq[<p><a href="./fhem?detail=$name">${Translations{'HTMLChart'}{'title'}{$language}}</a>];
+    $as_html .= sprintf(q{<p>%s: %s</p>},
+        $Translations{'HTMLChart'}{'data_start'}{$language},
+        ::ReadingsVal( $name, 'rainDataStart', 'unknown' )
+    );
     my $factor =
       ( $width ? $width : 700 ) / ( 1 + ::ReadingsVal( $name, 'rainMax', q{0} ) );
-    foreach my $val (@values) {
-        # @todo candidate for refactoring to sprintf
-        $as_html .=
-            q{<div style='width: }
-          . ( int( $val * $factor ) + 30 )
-          . q{px;'>}
-          . sprintf( '%.3f', $val )
-          . q{</div>};
+
+    $as_html .= q[<div class='htmlchart'>];
+    foreach my $bar_value (@values) {
+        $as_html .= sprintf(
+            q{<div style='width: %dpx'>%.3f</div>},
+            ( int( $bar_value * $factor ) + 30 ),
+            $bar_value
+        );
     }
 
-    $as_html .= q[</DIV><BR>];
+    $as_html .= q[</div>];
     return ($as_html);
 }
 

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -56,6 +56,7 @@ use Readonly;
 Readonly our $version               => '3.0.5';
 Readonly our $default_interval      => ONE_MINUTE * 2;
 Readonly our $debugging_min_verbose => 4;
+Readonly our $default_region        => q{de};
 
 =pod
     Translations
@@ -182,7 +183,7 @@ sub Initialize {
 
     my ($hash) = @_;
 
-    $hash->{DefFn}       = 'FHEM::Buienradar::Define';
+    $hash->{DefFn}       = \&FHEM::Buienradar::Define;
     $hash->{UndefFn}     = 'FHEM::Buienradar::Undefine';
     $hash->{GetFn}       = 'FHEM::Buienradar::Get';
     $hash->{SetFn}       = 'FHEM::Buienradar::Set';
@@ -196,7 +197,7 @@ sub Initialize {
         )
     ) . qq[ $::readingFnAttributes ];
     $hash->{'.PNG'} = q{};
-    $hash->{REGION} = 'de';
+    $hash->{REGION} = $default_region;
 
     return;
 }

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -407,7 +407,7 @@ sub Attr {
                     return qq[${attribute_value} is not a valid value for disabled. Only 'on' or 'off' are allowed!]
                         if $attribute_value !~ /^(?: on | off | 0 | 1 )$/x;
 
-                    if ($attribute_value =~ /(?: on | 1)/x) {
+                    if ($attribute_value =~ /(?: on | 1 )/x) {
                         ::RemoveInternalTimer( $hash,\&FHEM::Buienradar::Timer );
                         Disable($name);
                         $hash->{NEXTUPDATE} = undef;
@@ -415,7 +415,7 @@ sub Attr {
                         return;
                     }
 
-                    if ($attribute_value =~ /(off|0)/x) {
+                    if ($attribute_value =~ /(?: off | 0 )/x) {
                         Enable($name);
                         Timer($hash);
                         return;
@@ -1245,7 +1245,7 @@ can be retrieved.</code></pre>
 <h3>Attribute</h3>
 <ul>
   <li>
-    <p><a name="disabled" id="disabled"></a> <code>disabled on|off</code> - Wenn <code>disabled</code> auf <code>on</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.</p>
+    <p><a name="disabled" id="disabled"></a> <code>disabled on|ofLf</code> - Wenn <code>disabled</code> auf <code>on</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.</p>
     <p><strong>Achtung!</strong> Aus Kompatibilitätsgründen zu <code>FHEM::IsDisabled()</code> wird bei einem Aufruf von <code>disabled</code> auch <code>disable</code> als weiteres Attribut gesetzt. Wird <code>disable</code> gesetzt oder gelöscht, beeinflusst dies <code>disabled</code> nicht! <em><code>disable</code> sollte nicht verwendet werden!</em></p>
   </li>
   <li>

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -379,7 +379,7 @@ sub Attr {
 
         when ('region') {
             return Error(qq[${attribute_value} ${FHEM::Buienradar::Translations{'Attr'}{'region'}{$language}}])
-                if $attribute_value !~ /^(de|nl)$/x and $command eq 'set';
+                if $attribute_value !~ /^(?: de | nl )$/x and $command eq 'set';
 
             given ($command) {
                 when ('set') {

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -47,7 +47,7 @@ use English;
 use Storable;
 use GPUtils qw(GP_Import GP_Export);
 use experimental qw( switch );
-use v5.10;
+use 5.10.0;
 use Readonly;
 
 =pod

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -556,6 +556,21 @@ END_MESSAGE
     return ($as_html);
 }
 
+=pod
+
+=cut
+sub GetGChartDataSet {
+    my $start = shift;
+    my $precipitation = shift;
+
+    my ($k, $v) = (
+        POSIX::strftime('%H:%M', localtime $start),
+        sprintf('%.3f', $precipitation)
+    );
+
+    return qq{['$k', $v]}
+}
+
 =over 1
 
 =item C<FHEM::Buienradar::GChart>
@@ -580,11 +595,7 @@ sub GChart {
     # read & parse stored data
     my %storedData = %{ Storable::thaw($hash->{'.SERIALIZED'}) };
     my $data = join ', ', map {
-        my ($k, $v) = (
-            POSIX::strftime('%H:%M', localtime $storedData{$_}{'start'}),
-            sprintf('%.3f', $storedData{$_}{'precipitation'})
-        );
-        qq{['$k', $v]}
+        GetGChartDataSet($storedData{$_}{'start'}, $storedData{$_}{'precipitation'});
     } sort keys %storedData;
 
     # create data for the GChart

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -449,8 +449,6 @@ sub Define {
     $hash->{LATITUDE}   = $latitude;
     $hash->{LONGITUDE}  = $longitude;
     $hash->{URL}        = undef;
-    # @todo this looks like a good candidate for a refactoring
-    $hash->{'.HTML'}    = '<DIV>';
     # get language for language dependend legend
     $FHEM::Buienradar::language = lc ::AttrVal('global', 'language', 'DE');
 

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -300,7 +300,7 @@ sub Get {
         when ('startsIn') {
             my $begin = $hash->{'.RainStart'};
             return q[No data available] unless $begin;
-            return q[It is raining] if $begin = 0;
+            return q[It is raining] if $begin == 0;
 
             my $timeDiffSec = $begin - time;
             return scalar timediff2str($timeDiffSec);

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -353,9 +353,9 @@ sub Attr {
             given ($command) {
                 when ('set') {
                     return qq[${attribute_value} is not a valid value for disabled. Only 'on' or 'off' are allowed!]
-                        if $attribute_value !~ /^(on|off|0|1)$/;
+                        if $attribute_value !~ /^(on|off|0|1)$/x;
 
-                    if ($attribute_value =~ /(on|1)/) {
+                    if ($attribute_value =~ /(on|1)/x) {
                         ::RemoveInternalTimer( $hash,\&FHEM::Buienradar::Timer );
                         $::attr{$device_name}{'disable'} = 1;
                         $hash->{NEXTUPDATE} = undef;
@@ -363,7 +363,7 @@ sub Attr {
                         return;
                     }
 
-                    if ($attribute_value =~ /(off|0)/) {
+                    if ($attribute_value =~ /(off|0)/x) {
                         $::attr{$device_name}{'disable'} = 0;
                         Timer($hash);
                         return;
@@ -379,7 +379,7 @@ sub Attr {
 
         when ('region') {
             return Error(qq[${attribute_value} ${FHEM::Buienradar::Translations{'Attr'}{'region'}{$language}}])
-                if $attribute_value !~ /^(de|nl)$/ and $command eq 'set';
+                if $attribute_value !~ /^(de|nl)$/x and $command eq 'set';
 
             given ($command) {
                 when ('set') {
@@ -397,7 +397,7 @@ sub Attr {
 
         when ('interval') {
             return FHEM::Buienradar::Error(qq[${attribute_value} ${FHEM::Buienradar::Translations{'Attr'}{'interval'}{$language}}])
-                if $attribute_value !~ /^(10|60|120|180|240|300)$/ and $command eq 'set';
+                if $attribute_value !~ /^(10|60|120|180|240|300)$/x and $command eq 'set';
 
             given ($command) {
                 when ('set') {
@@ -518,7 +518,7 @@ sub RequestUpdate {
 sub HTML {
     my ( $name, $width ) = @_;
     my $hash = $::defs{$name};
-    my @values = split /:/, ::ReadingsVal($name, 'rainData', '0:0');
+    my @values = split /:/x, ::ReadingsVal($name, 'rainData', '0:0');
 
     my $as_html = <<'END_MESSAGE';
 <style>

--- a/FHEM/59_Buienradar.pm
+++ b/FHEM/59_Buienradar.pm
@@ -56,7 +56,7 @@ use Readonly;
 =pod
     Settings
 =cut
-Readonly our $version               => '3.0.5';
+Readonly our $version               => '3.0.6';
 Readonly our $default_interval      => ONE_MINUTE * 2;
 Readonly our $debugging_min_verbose => 4;
 Readonly our $default_region        => q{de};
@@ -1160,14 +1160,17 @@ can be retrieved.</code></pre>
     <pre><code>  { FHEM::Buienradar::LogProxy("buienradar device name")}</code></pre>
   </li>
   <li>
-    <p>A plain text representation can be display by</p>
-    <pre><code>  { FHEM::Buienradar::TextChart("buienradar device name")}</code></pre>
-    <p>Every line represents a record of the whole set in a format like</p>
-    <pre><code>  22:25 |   0.060 | =
-  22:30 |   0.370 | ====
-  22:35 |   0.650 | =======</code></pre>
-    <p>For every 0.1 mm/h precipitation a <code>=</code> is displayed, but the output is capped to 50 units. If more than 50 units would be display, the bar is appended with a <code>&gt;</code>.</p>
-    <pre><code>  23:00 |  11.800 | ==================================================&gt;</code></pre>
+    <p>A plain text representation can be displayed with</p>
+    <pre><code>  { FHEM::Buienradar::TextChart(q{buienradar device name}, q{bar chart character})}</code></pre>
+    <p>The bar chart character is optional and defaults to <code>=</code>.</p>
+    <p>Every line represents a record of the whole set, i.e. if called by</p>
+    <pre><code>  { FHEM::Buienradar::TextChart(q{buienradar_test_device}, q{#})}</code></pre>
+    <p>the result will look similar to</p>
+    <pre><code>  22:25 |   0.060 | #
+  22:30 |   0.370 | ####
+  22:35 |   0.650 | #######</code></pre>
+    <p>For every 0.1 mm/h precipitation a <code>#</code> is displayed, but the output is capped to 50 units. If more than 50 units would be display, the bar is truncated and appended with a <code>&gt;</code>.</p>
+    <pre><code>  23:00 |  11.800 | ##################################################&gt;</code></pre>
   </li>
 </ul>
 
@@ -1245,7 +1248,7 @@ can be retrieved.</code></pre>
 <h3>Attribute</h3>
 <ul>
   <li>
-    <p><a name="disabled" id="disabled"></a> <code>disabled on|ofLf</code> - Wenn <code>disabled</code> auf <code>on</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.</p>
+    <p><a name="disabled" id="disabled"></a> <code>disabled on|off</code> - Wenn <code>disabled</code> auf <code>on</code> gesetzt wird, wird das Device keine weiteren Anfragen mehr an Buienradar.nl durchführen. <code>off</code> reaktiviert das Modul, ebenso wenn das Attribut gelöscht wird.</p>
     <p><strong>Achtung!</strong> Aus Kompatibilitätsgründen zu <code>FHEM::IsDisabled()</code> wird bei einem Aufruf von <code>disabled</code> auch <code>disable</code> als weiteres Attribut gesetzt. Wird <code>disable</code> gesetzt oder gelöscht, beeinflusst dies <code>disabled</code> nicht! <em><code>disable</code> sollte nicht verwendet werden!</em></p>
   </li>
   <li>
@@ -1272,13 +1275,15 @@ abgerufen werden.</code></pre>
   </li>
   <li>
     <p>Für eine reine Text-Ausgabe der Daten als Graph, kann</p>
-    <pre><code>  { FHEM::Buienradar::TextChart("name des buienradar device")}</code></pre>
-    <p>verwendet werden. Ausgegeben wird ein für jeden Datensatz eine Zeile im Muster</p>
-    <pre><code>  22:25 |   0.060 | =
-  22:30 |   0.370 | ====
-  22:35 |   0.650 | =======</code></pre>
-    <p>wobei für jede 0.1 mm/h Niederschlag ein <code>=</code> ausgegeben wird, maximal jedoch 50 Einheiten. Mehr werden mit einem <code>&gt;</code> abgekürzt.</p>
-    <pre><code>  23:00 |  11.800 | ==================================================&gt;</code></pre>
+    <pre><code>  { FHEM::Buienradar::TextChart(q{name des buienradar device}, q{verwendetes zeichen})}</code></pre>
+    <p>verwendet werden. Das <code>verwendete zeichen</code> ist optional und mit <code>=</code> vorbelegt. Ausgegeben wird beispielsweise für den Aufruf</p>
+    <pre><code>  { FHEM::Buienradar::TextChart(q{buienradar_test}, q{#}) }</code></pre>
+    <p>für jeden Datensatz eine Zeile im Muster</p>
+    <pre><code>  22:25 |   0.060 | #
+  22:30 |   0.370 | ###
+  22:35 |   0.650 | #######</code></pre>
+    <p>wobei für jede 0.1 mm/h Niederschlag das <code>#</code> verwendet wird, maximal jedoch 50 Einheiten. Mehr werden mit einem <code>&gt;</code> abgekürzt.</p>
+    <pre><code>  23:00 |  11.800 | ##################################################&gt;</code></pre>
   </li>
 </ul>
 
@@ -1288,7 +1293,7 @@ abgerufen werden.</code></pre>
 
 =for :application/json;q=META.json 59_Buienradar.pm
 {
-    "abstract": "FHEM module for precipiation forecasts basing on buienradar.nl",
+    "abstract": "FHEM module for precipitation forecasts basing on buienradar.nl",
     "x_lang": {
         "de": {
             "abstract": "FHEM-Modul f&uuml;r Regen- und Regenmengenvorhersagen auf Basis von buienradar.nl"
@@ -1296,7 +1301,7 @@ abgerufen werden.</code></pre>
     },
     "keywords": [
         "Buienradar",
-        "Precipiation",
+        "Precipitation",
         "Rengenmenge",
         "Regenvorhersage",
         "hoeveelheid regen",
@@ -1305,7 +1310,7 @@ abgerufen werden.</code></pre>
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "3.0.5",
+    "version": "3.0.6",
     "author": [
         "Christoph Morrison <post@christoph-jeschke.de>"
     ],

--- a/Waiver.md
+++ b/Waiver.md
@@ -1,4 +1,4 @@
-# Copyright waiver for <http://example.org/projects/hello-world>
+# Copyright waiver for FHEM::Buienradar
 
 I dedicate any and all copyright interest in this software to the
 public domain. I make this dedication for the benefit of the public at

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,2 +1,2 @@
 DEL ./FHEM/59_Buienradar.pm
-UPD 2020-04-14_13:32:42 41584 FHEM/59_Buienradar.pm
+UPD 2020-04-24_19:09:57 44771 FHEM/59_Buienradar.pm

--- a/meta.json
+++ b/meta.json
@@ -16,7 +16,7 @@
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "3.0.5",
+    "version": "3.0.6",
     "author": [
         "Christoph Morrison <post@christoph-jeschke.de>"
     ],

--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,5 @@
 {
-    "abstract": "FHEM module for precipiation forecasts basing on buienradar.nl",
+    "abstract": "FHEM module for precipitation forecasts basing on buienradar.nl",
     "x_lang": {
         "de": {
             "abstract": "FHEM-Modul f&uuml;r Regen- und Regenmengenvorhersagen auf Basis von buienradar.nl"
@@ -7,7 +7,7 @@
     },
     "keywords": [
         "Buienradar",
-        "Precipiation",
+        "Precipitation",
         "Rengenmenge",
         "Regenvorhersage",
         "hoeveelheid regen",


### PR DESCRIPTION
# Changes

## Documentation
- Fixes #81 Waiver is now specific for FHEM::Buienradar
- Fixes #109 fixed mispelling in meta.json

## Bugs
- Fixes #82 Missing `=`
- Fixes #92 The TextChart output was garbled, line breaks were missing
- Fixes #94 Uncaught SyntaxError: Unexpected token '{'
- Fixes #95 PERL WARNING: Use of uninitialized value $FHEM::Buienradar::device_name in concatenation
- Fixes #87 Removed globally used device name

## Enhancements
- Fixes #84 I18N for non-valid interval error message
- Fixes #85 Refactored the logging and debugging to a less verbose version
- Fixes #83 I18N for non-valid region attribute error message
- Fixes #46 Version string is now a real number (PBP)
- Fixes #89 The default region is moved to the `configuration` section and is read-only
- Fixes #45 used refs to subroutines instead of named strings
- Fixes #88 removed obsolete Internal .PNG
- Fixes #90 removed obsolete internal .HTML
- Fixes #44 The TextChart bar characater is now configurable and defaults to =
- Fixes #76 Don't use package var
- Fixes #75 Don't use package var
- Fixes #74 Don't use package var
- Fixes #73 Don't use package var
- Fixes #68 Don't use package var
- Fixes #67 Don't use package var
- Fixes #48 Don't use package var
- Fixes #47 Don't use package var
- Fixes #79 moved the insides for the TextChart bar to a independent subroutine
- Fixes #72 moved the insides for the GoogleChart data set to a independent subroutine
- Fixes #57 Regular expression without "/x" flag
- Fixes #58 Regular expression without "/x" flag
- Fixes #60 Regular expression without "/x" flag
- Fixes #64 Regular expression without "/x" flag
- Fixes #66 Regular expression without "/x" flag
- Fixes #70 Regular expression without "/x" flag
- Fixes #56 No regex capturing if not required
- Fixes #96 No regex capturing if not required
- Fixes #63 No regex capturing if not required
- Fixes #65 No regex capturing if not required
- Fixes #78 Package variable declared or used: accessing %::defs via wrapper, instead of direct access
- Fixes #77 Package variable declared or used: accessing %::defs via wrapper, instead of direct access
- Fixes #71 Package variable declared or used: accessing %::defs via wrapper, instead of direct access
- Fixes #69 Package variable declared or used: accessing %::defs via wrapper, instead of direct access
- Fixes #55 Package variable declared or used: accessing %::defs via wrapper, instead of direct access
- Fixes #54 Package variable declared or used: accessing %::defs via wrapper, instead of direct access
- Fixes #62 Package variable declared or used: accessing %::defs via wrapper, instead of direct access
- Fixes #61 Package variable declared or used: accessing %::defs via wrapper, instead of direct access
- Fixes #59 Package variable declared or used: accessing %::defs via wrapper, instead of direct access
- Fixes #99 Silenced Perl::Critic warnings for mismatch package declaration and file name since the FHEM API mandates this construct ATM
- Fixes #100 disabled Perl::Critic for ATM not solvable access to FHEMs %main::defs
- Fixes #97 Reused variable name in lexical scope: $device_name
- Fixes #102 I18N for the labels in the HTML chart
- Fixes #98 Beautified the HTML charts markup
- Fixes #93 refactored the bogus `define` error message, don't I18N it
- Fixes #108 No regex capturing if not required