### PR TITLE
Pre-Release 3.1.0-10

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,9 +18,9 @@ jobs:
         id: extract_branch
       - name: Checkout Repository
         uses: actions/checkout@master
-      - name: Add Documentation
-        run: |
-          bash $DOCUMENTATION_SCRIPT
+#      - name: Add Documentation
+#        run: |
+#          bash $DOCUMENTATION_SCRIPT
       - name: Update CHANGED file
         run: |
           LOG=$(date +"%Y-%m-%d")

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-10-22 - #335 Disabled documentation
 2021-10-15 - #335 Manually fixed the size for 59_Buienradar.pm
 
 #335 Manually fixed the size for 59_Buienradar.pm for a spot on fix for users who can't update anymore

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-09-14 - #131 fixed startsIn if it's rainin right now reporting nothing back
 2021-09-14 - #327 fixed double return
 2021-09-14 - #324 fixed typo in $ARGUMENT_LENGHT_WITH_LOC
 2021-09-14 - #326 refactored request url build, workaround for #325, but not an adequate solution

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-09-14 - #324 fixed typo in $ARGUMENT_LENGHT_WITH_LOC
 2021-09-14 - #326 refactored request url build, workaround for #325, but not an adequate solution
 2021-09-06 - Merge branch 'release/3.0' into development/3.0
 2020-06-09 - Bump to v3.0.9

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-09-30 - Back to 3.1.0-10
 2021-09-30 - #329 #328 added i18n for starts in
 2021-09-28 - #130 rainBeginUnixtime added, delivers the next precipitation as unix timestamp or -1 if no precipitation is predicted
 2021-09-26 - Use docker, update vagrant to bullseye

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-09-15 - #321 updated comments
 2021-09-14 - #131 fixed startsIn if it's rainin right now reporting nothing back
 2021-09-14 - #327 fixed double return
 2021-09-14 - #324 fixed typo in $ARGUMENT_LENGHT_WITH_LOC

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-09-25 - #332 Be less verbose
 2021-09-20 - Bump to semantic version 3.1.0-10
 2021-09-19 - #326 #325 fix for the fix for the fix
 2021-09-19 - #326 #325 fix for the fix

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-09-19 - #326 #325 fix for the fix for the fix
 2021-09-19 - #326 #325 fix for the fix
 2021-09-15 - #321 updated comments
 2021-09-14 - #131 fixed startsIn if it's rainin right now reporting nothing back

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-09-30 - #329 #328 added i18n for starts in
 2021-09-28 - #130 rainBeginUnixtime added, delivers the next precipitation as unix timestamp or -1 if no precipitation is predicted
 2021-09-26 - Use docker, update vagrant to bullseye
 2021-09-25 - #332 Be less verbose

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-09-26 - Use docker, update vagrant to bullseye
 2021-09-25 - #332 Be less verbose
 2021-09-20 - Bump to semantic version 3.1.0-10
 2021-09-19 - #326 #325 fix for the fix for the fix

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-09-20 - Bump to semantic version 3.1.0-10
 2021-09-19 - #326 #325 fix for the fix for the fix
 2021-09-19 - #326 #325 fix for the fix
 2021-09-15 - #321 updated comments

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-09-19 - #326 #325 fix for the fix
 2021-09-15 - #321 updated comments
 2021-09-14 - #131 fixed startsIn if it's rainin right now reporting nothing back
 2021-09-14 - #327 fixed double return

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-10-14 - #333 #328 Added sanity checks for latitude and longitude
 2021-09-30 - Back to 3.1.0-10
 2021-09-30 - #329 #328 added i18n for starts in
 2021-09-28 - #130 rainBeginUnixtime added, delivers the next precipitation as unix timestamp or -1 if no precipitation is predicted

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-09-28 - #130 rainBeginUnixtime added, delivers the next precipitation as unix timestamp or -1 if no precipitation is predicted
 2021-09-26 - Use docker, update vagrant to bullseye
 2021-09-25 - #332 Be less verbose
 2021-09-20 - Bump to semantic version 3.1.0-10

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-09-14 - #327 fixed double return
 2021-09-14 - #324 fixed typo in $ARGUMENT_LENGHT_WITH_LOC
 2021-09-14 - #326 refactored request url build, workaround for #325, but not an adequate solution
 2021-09-06 - Merge branch 'release/3.0' into development/3.0

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,6 @@
+2021-10-15 - #335 Manually fixed the size for 59_Buienradar.pm
+
+#335 Manually fixed the size for 59_Buienradar.pm for a spot on fix for users who can't update anymore
 2021-10-14 - #333 #328 Added sanity checks for latitude and longitude
 2021-09-30 - Back to 3.1.0-10
 2021-09-30 - #329 #328 added i18n for starts in

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2021-09-14 - #326 refactored request url build, workaround for #325, but not an adequate solution
 2021-09-06 - Merge branch 'release/3.0' into development/3.0
 2020-06-09 - Bump to v3.0.9
 2020-06-09 - Restore changes to FUNDING

--- a/CommandRef.de.md
+++ b/CommandRef.de.md
@@ -48,6 +48,8 @@ Aktuell liefert Buienradar folgende Readings:
 
 * ``rainBegin``             - Beginn des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.
 
+* `rainBeginUnixtime`       - Beginn des nächsten Niederschlags als Unixzeit (in UTC/GMT), <var>-1</var> wenn kein Niederschlag vorhergesagt wurde
+
 * ``raindEnd``              - Ende des nächsten Niederschlag. Wenn kein Niederschlag gemeldet ist, <var>unknown</var>.
 
 * ``rainDataStart``         - Zeitlicher Beginn der gelieferten Niederschlagsdaten.

--- a/CommandRef.en.md
+++ b/CommandRef.en.md
@@ -50,6 +50,8 @@ Buienradar provides several readings:
 
 * ``rainBegin``             - starting time of the next precipitation, <var>unknown</var> if no precipitation is predicted.
 
+* `rainBeginUnixtime`       - starting time of the next precipitation in unix seconds, <var>-1</var> if no precipitation is predicted.
+
 * ``raindEnd``              - ending time of the next precipitation, <var>unknown</var> if no precipitation is predicted.
 
 * ``rainDataStart``         - starting time of gathered data.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,12 +10,14 @@
 Vagrant.configure("2") do |config|
 
     config.vm.define "buienradar-dev" do |machine|
-        machine.vm.box = "debian/contrib-buster64"
+        machine.vm.box = "debian/bullseye64"
         machine.vm.hostname = "FHEM-Buienradar-Dev"
 
         machine.vm.network "public_network", bridge: [
             "en0: WLAN (AirPort)",
-            "en0: Ethernet"
+            "en0: Ethernet",
+            "en8: Monitor-Ethernet",
+            "en10: Thunderbolt Ethernet Slot 2"
         ]
 
         # mount for later created user "fhem" with later uid 999

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-09-30_13:40:26 58237 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-10-14_12:24:16 61658 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-09-30_13:40:26 13538 FHEM/59_Buienradar.pm
+UPD 2021-10-14_12:24:16 13538 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-10-14_12:24:16 61658 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-10-15_09:58:00 61658 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-10-14_12:24:16 13537 FHEM/59_Buienradar.pm
+UPD 2021-10-15_09:58:00 13538 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-09-14_20:32:30 55134 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-09-15_08:59:35 54670 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-09-14_20:32:31 13197 FHEM/59_Buienradar.pm
+UPD 2021-09-15_08:59:35 13197 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-09-20_15:40:08 54676 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-09-25_17:01:37 54595 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-09-20_15:40:08 13197 FHEM/59_Buienradar.pm
+UPD 2021-09-25_17:01:37 13197 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-09-14_19:59:21 54987 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-09-14_20:13:46 54980 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-09-14_19:59:21 13197 FHEM/59_Buienradar.pm
+UPD 2021-09-14_20:13:46 13197 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-09-26_19:31:47 56946 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-09-28_09:16:06 57405 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-09-26_19:31:47 13197 FHEM/59_Buienradar.pm
+UPD 2021-09-28_09:16:07 13538 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-09-14_19:54:21 54987 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-09-14_19:59:21 54987 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-09-14_19:54:22 13197 FHEM/59_Buienradar.pm
+UPD 2021-09-14_19:59:21 13197 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
 UPD 2021-10-14_12:24:16 61658 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-10-14_12:24:16 13538 FHEM/59_Buienradar.pm
+UPD 2021-10-14_12:24:16 13537 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-09-28_09:16:06 57405 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-09-30_11:11:02 58237 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-09-28_09:16:07 13538 FHEM/59_Buienradar.pm
+UPD 2021-09-30_11:11:03 13538 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-09-15_08:59:35 54670 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-09-19_10:53:41 54670 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-09-15_08:59:35 13197 FHEM/59_Buienradar.pm
+UPD 2021-09-19_10:53:42 13197 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-09-06_10:57:58 55057 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-09-14_19:54:21 54987 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-09-06_10:57:58 13197 FHEM/59_Buienradar.pm
+UPD 2021-09-14_19:54:22 13197 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-10-15_09:58:00 61658 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-10-22_21:15:14 61658 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-10-15_09:58:00 13538 FHEM/59_Buienradar.pm
+UPD 2021-10-22_21:15:14 13197 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-09-14_20:13:46 54980 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-09-14_20:32:30 55134 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-09-14_20:13:46 13197 FHEM/59_Buienradar.pm
+UPD 2021-09-14_20:32:31 13197 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-09-19_10:58:40 54671 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-09-20_15:40:08 54676 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-09-19_10:58:40 13197 FHEM/59_Buienradar.pm
+UPD 2021-09-20_15:40:08 13197 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-09-30_11:11:02 58237 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-09-30_13:40:26 58237 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-09-30_11:11:03 13538 FHEM/59_Buienradar.pm
+UPD 2021-09-30_13:40:26 13538 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-09-19_10:53:41 54670 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-09-19_10:58:40 54671 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-09-19_10:53:42 13197 FHEM/59_Buienradar.pm
+UPD 2021-09-19_10:58:40 13197 FHEM/59_Buienradar.pm

--- a/controls_Buienradar.txt
+++ b/controls_Buienradar.txt
@@ -1,4 +1,4 @@
 DEL lib/FHEM/Weather/Buienradar.pm
-UPD 2021-09-25_17:01:37 54595 lib/FHEM/Weather/Buienradar.pm
+UPD 2021-09-26_19:31:47 56946 lib/FHEM/Weather/Buienradar.pm
 DEL FHEM/59_Buienradar.pm
-UPD 2021-09-25_17:01:37 13197 FHEM/59_Buienradar.pm
+UPD 2021-09-26_19:31:47 13197 FHEM/59_Buienradar.pm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  fhem-buienradar:
+    restart: always
+    ports:
+      - "10001:8083"
+    image: fhem/fhem:latest
+    volumes:
+      - ./:/opt/buienradar

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -157,7 +157,6 @@ sub initialize_module {
 
 sub handle_fhemweb_details {
     my $name            = shift;
-    my $room            = shift;
     my $page_definition = shift;
     my $hash            = get_device_definition($name);
 

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -21,7 +21,7 @@ use Readonly;
 use FHEM::Meta;
 
 ############################################################    Default values
-Readonly our $VERSION               => q{3.0.10};
+Readonly our $VERSION               => q{3.1.0-10};
 Readonly our $DEFAULT_INTERVAL      => ONE_MINUTE * 2;
 Readonly our $DEBUGGING_MIN_VERBOSE => 2;
 Readonly our $DEFAULT_REGION        => q{de};

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -16,7 +16,7 @@ use English qw( -no_match_vars );
 use Storable;
 use GPUtils;
 use experimental qw( switch );
-use 5.0260;    # we do not want perl be older than from 2007, so > 5.13.9
+use 5.0260;    # we use intended heredoc, introduced with 5.0.26
 use Readonly;
 use FHEM::Meta;
 

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -22,7 +22,7 @@ use English qw( -no_match_vars );
 use Storable;
 use GPUtils;
 use experimental qw( switch );
-use 5.0139;    # we do not want perl be older than from 2007, so > 5.13.9
+use 5.0260;    # we do not want perl be older than from 2007, so > 5.13.9
 use Readonly;
 use FHEM::Meta;
 
@@ -263,7 +263,7 @@ sub handle_set {
     my @args = shift;
 
     if ( !defined $opt ) {
-        return return qq{'set $name' needs at least one argument};
+        return qq{'set $name' needs at least one argument};
     }
 
     for ($opt) {

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -577,8 +577,8 @@ sub get_global_language {
 sub debug_message {
     local $OFS = qq{\n};
     my $device_name = shift;
-    if ( int( ::AttrVal( q{global}, q{verbose}, 0 ) ) >= $DEBUGGING_MIN_VERBOSE
-        or int( ::AttrVal( $device_name, q{debug}, 0 ) ) == 1 )
+
+    if ( int( ::AttrVal( $device_name, q{debug}, 0 ) ) == 1 )
     {
         ::Debug( join $OFS, ( qq{[$device_name]}, qq{@_} ) );
     }

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -886,7 +886,7 @@ sub request_data_update {
     $hash->{URL} =  ::AttrVal( $name, 'BaseUrl',
         sprintf
             q(https://cdn-secure.buienalarm.nl/api/3.4/forecast.php?region=%s&lat=%s&lon=%s&unit=mm/u),
-            $region
+            $region,
             $hash->{LATITUDE},
             $hash->{LONGITUDE},
     );

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -917,7 +917,6 @@ sub request_data_update {
 sub chart_html_bar {
     my $name     = shift;
     my $width    = shift;
-    my $hash     = get_device_definition($name);
     my @values   = split /:/xms, ::ReadingsVal( $name, 'rainData', '0:0' );
     my $language = get_global_language();
 

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -650,7 +650,7 @@ sub parse_http_response {
     # todo: secondary usage!
     Readonly my $MINUTES_IN_HOUR            => 60;
     Readonly my $TOTAL_PERCENTAGE           => 100;
-    Readonly my $LAMETRIC_MULTIPILIER       => 1000;
+    Readonly my $LAMETRIC_MULTIPLIER        => 1000;
     Readonly my $LAMETRIC_MAX_VALUES        => 12;
 
     my %precipitation_forecast;
@@ -728,7 +728,7 @@ sub parse_http_response {
         #    q{Received data: } . Dumper( @{ $forecast_data->{'precip'} } ) );
 
         if ( scalar @precip > 0 ) {
-            my $data_lametric = join q{,}, map { $_ * $LAMETRIC_MULTIPILIER } @precip[ 0 .. $LAMETRIC_MAX_VALUES-1 ];
+            my $data_lametric = join q{,}, map { $_ * $LAMETRIC_MULTIPLIER } @precip[ 0 .. $LAMETRIC_MAX_VALUES-1 ];
             my $rain_total    = List::Util::sum @precip;
             my $rain_max      = List::Util::max @precip;
             my $rain_start    = undef;

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -10,7 +10,7 @@ use HttpUtils;
 use JSON;
 use List::Util;
 use Time::Seconds;
-use POSIX;
+use POSIX ();
 use Data::Dumper;
 use English qw( -no_match_vars );
 use Storable;

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -21,7 +21,6 @@ use Readonly;
 use FHEM::Meta;
 
 ############################################################    Default values
-Readonly our $VERSION               => q{3.1.0-10};
 Readonly our $DEFAULT_INTERVAL      => ONE_MINUTE * 2;
 Readonly our $DEBUGGING_MIN_VERBOSE => 2;
 Readonly our $DEFAULT_REGION        => q{de};
@@ -30,6 +29,7 @@ Readonly our $DEFAULT_LANGUAGE      => q{en};
 Readonly our $DEFAULT_LATITUDE      => 51.0;
 Readonly our $DEFAULT_LONGITUDE     => 7.0;
 Readonly our $MAX_TEXT_BAR_LENGTH    => 50;
+Readonly my $VERSION                        => q{3.1.0-11};
 
 ############################################################    Translations
 Readonly my %TRANSLATIONS => (

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -141,7 +141,8 @@ sub initialize_module {
             'disabled:on,off',
             'region:nl,de',
             'interval:10,60,120,180,240,300',
-            'default_chart:none,HTMLChart,GChart,TextChart'
+            'default_chart:none,HTMLChart,GChart,TextChart',
+            q{debug:0,1}
         )
     ) . qq[ $::readingFnAttributes ];
     $hash->{REGION} = $DEFAULT_REGION;
@@ -416,6 +417,12 @@ sub handle_attributes {
             }
         }
 
+        when (q{debug}) {
+            if ( !List::Util::any { $_ eq $attribute_value } qw{ on off 0 1 } ) {
+                return qq[$attribute_value is not a valid value for debug]
+            }
+        }
+
         when ('region') {
             return handle_error( $name,
                 qq[${attribute_value} ${TRANSLATIONS{'handle_attributes'}{'region'}{$language}}]
@@ -578,9 +585,8 @@ sub debug_message {
     local $OFS = qq{\n};
     my $device_name = shift;
 
-    if ( int( ::AttrVal( $device_name, q{debug}, 0 ) ) == 1 )
-    {
-        ::Debug( join $OFS, ( qq{[$device_name]}, qq{@_} ) );
+    if ( ::AttrVal($device_name, q{debug}, 0) == 1 or ::AttrVal(q{global}, q{br_debug}, 0) == 1 ) {
+        ::Debug( join $OFS, ( qq{[$device_name]}, Dumper(\@_) ) );
     }
 
     return;

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -640,7 +640,7 @@ sub parse_http_response {
     $hash->{'.RainStart'} = undef;
 
     Readonly my $INTERVAL_LENGTH_MINUTES    => 5;
-    Readonly my $INTERVAL_LENGHT_SECONDS    => $INTERVAL_LENGTH_MINUTES * ONE_MINUTE;
+    Readonly my $INTERVAL_LENGTH_SECONDS    => $INTERVAL_LENGTH_MINUTES * ONE_MINUTE;
     # todo: secondary usage!
     Readonly my $MINUTES_IN_HOUR            => 60;
     Readonly my $TOTAL_PERCENTAGE           => 100;
@@ -728,7 +728,7 @@ sub parse_http_response {
             my $rain_start    = undef;
             my $rain_end      = undef;
             my $data_start    = $forecast_data->{start};
-            my $data_end = $data_start + ( scalar @precip ) * $INTERVAL_LENGHT_SECONDS;
+            my $data_end = $data_start + ( scalar @precip ) * $INTERVAL_LENGTH_SECONDS;
             my $forecast_start      = $data_start;
             my $rain_now            = undef;
             my $rain_data           = join q{:}, @precip;
@@ -740,8 +740,8 @@ sub parse_http_response {
 
             for my $precip_index ( 0 .. $precip_length-1 ) {
 
-                my $start  = $forecast_start + $precip_index * $INTERVAL_LENGHT_SECONDS;
-                my $end    = $start +  $INTERVAL_LENGHT_SECONDS;
+                my $start  = $forecast_start + $precip_index * $INTERVAL_LENGTH_SECONDS;
+                my $end    = $start +  $INTERVAL_LENGTH_SECONDS;
                 my $precipitation_amount = $precip[$precip_index];
                 $is_raining = undef;    # reset
 

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -156,7 +156,6 @@ sub initialize_module {
 }
 
 sub handle_fhemweb_details {
-    my $fhemweb_name    = shift;
     my $name            = shift;
     my $room            = shift;
     my $page_definition = shift;

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -249,7 +249,6 @@ sub handle_define {
 
 sub handle_undefine {
     my $hash = shift;
-    my $arg  = shift;
     ::RemoveInternalTimer( $hash, \&update_timer );
     return;
 }

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -892,16 +892,14 @@ sub request_data_update {
     my $region = $hash->{REGION};
     my $name   = $hash->{NAME};
 
-    # @todo candidate for refactoring to sprintf
-    $hash->{URL} =
-        ::AttrVal( $name, 'BaseUrl',
-            'https://cdn-secure.buienalarm.nl/api/3.4/forecast.php' )
-            . '?lat='
-            . $hash->{LATITUDE} . '&lon='
-            . $hash->{LONGITUDE}
-            . '&region='
-            . $region
-            . '&unit=' . 'mm/u';
+    $hash->{URL} =  ::AttrVal( $name, 'BaseUrl',
+        sprintf(
+            q(https://cdn-secure.buienalarm.nl/api/3.4/forecast.php?lat=%s&lon=%s&region=%s&unit=mm/u),
+                $hash->{LATITUDE},
+                $hash->{LONGITUDE},
+                $region
+        )
+    );
 
     my $param = {
         url      => $hash->{URL},

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -198,7 +198,7 @@ sub handle_define {
     my $language = get_global_language();
 
     Readonly my $ARGUMENT_LENGTH_WITHOUT_LOC    => 2;
-    Readonly my $ARGUMENT_LENGHT_WITH_LOC       => 4;
+    Readonly my $ARGUMENT_LENGTH_WITH_LOC       => 4;
     Readonly my $ARGUMENT_POSITION_LATITUDE     => 2;
     Readonly my $ARGUMENT_POSITION_LONGITUDE    => 3;
     Readonly my $ARGUMENT_DEFINE_START          => 2;
@@ -208,7 +208,7 @@ sub handle_define {
         $latitude  = ::AttrVal( 'global', 'latitude',  $DEFAULT_LATITUDE );
         $longitude = ::AttrVal( 'global', 'longitude', $DEFAULT_LONGITUDE );
     }
-    elsif ( $arguments_length == $ARGUMENT_LENGHT_WITH_LOC ) {
+    elsif ( $arguments_length == $ARGUMENT_LENGTH_WITH_LOC ) {
         $latitude  = $arguments[$ARGUMENT_POSITION_LATITUDE];
         $longitude = $arguments[$ARGUMENT_POSITION_LONGITUDE];
     }

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -195,7 +195,6 @@ sub handle_define {
     my $arguments_length = scalar @arguments;
     my $latitude;
     my $longitude;
-    my $language = get_global_language();
 
     Readonly my $ARGUMENT_LENGTH_WITHOUT_LOC    => 2;
     Readonly my $ARGUMENT_LENGTH_WITH_LOC       => 4;

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -21,7 +21,7 @@ use Readonly;
 use FHEM::Meta;
 
 ############################################################    Default values
-Readonly my $VERSION                        => q{3.1.0-12};
+Readonly my $VERSION                        => q{3.1.0-10};
 Readonly my $DEFAULT_INTERVAL               => ONE_MINUTE * 2;
 Readonly my $DEFAULT_REGION                 => q{nl};
 Readonly my $DEFAULT_TEXT_BAR_CHAR          => q{=};

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -885,10 +885,10 @@ sub request_data_update {
 
     $hash->{URL} =  ::AttrVal( $name, 'BaseUrl',
         sprintf
-            q(https://cdn-secure.buienalarm.nl/api/3.4/forecast.php?lat=%s&lon=%s&region=%s&unit=mm/u),
+            q(https://cdn-secure.buienalarm.nl/api/3.4/forecast.php?region=%s&lat=%s&lon=%s&unit=mm/u),
+            $region
             $hash->{LATITUDE},
             $hash->{LONGITUDE},
-            $region
     );
 
     my $param = {

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -296,12 +296,15 @@ sub handle_get {
         # @todo I18N
         when ('startsIn') {
             my $begin = $hash->{'.RainStart'};
+            my $is_raining = (::ReadingsVal($name, q(rainNow), undef) eq q(unknown) ? 0 : 1);
 
             if ( !$begin ) {
                 return q[No data available];
             }
 
-            return q[It is raining] if $begin == 0;
+            if ($begin == 0 && $is_raining) {
+                return q[It is raining right now] ;
+            }
 
             my $time_diff_in_seconds = $begin - time;
             return scalar timediff2str($time_diff_in_seconds);

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -890,12 +890,11 @@ sub request_data_update {
     my $name   = $hash->{NAME};
 
     $hash->{URL} =  ::AttrVal( $name, 'BaseUrl',
-        sprintf(
+        sprintf
             q(https://cdn-secure.buienalarm.nl/api/3.4/forecast.php?lat=%s&lon=%s&region=%s&unit=mm/u),
-                $hash->{LATITUDE},
-                $hash->{LONGITUDE},
-                $region
-        )
+            $hash->{LATITUDE},
+            $hash->{LONGITUDE},
+            $region
     );
 
     my $param = {

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -1,12 +1,6 @@
 ## no critic (RequireFilenameMatchesPackage, CodeLayout::RequireTidyCode, Documentation::PodSpelling)
-# #   JFTR:
-#
-#   ATM, it's not possible to comply to this Perl::Critic rule, because
-#   the current state of the FHEM API does require this bogus XX_Name.pm convention
-#
-#   Disabled spell checkers
-#
-#   Perl::Tidy sucks 🗿
+#  Disabled spell checkers
+
 package FHEM::Weather::Buienradar;
 ############################################################    Pragmas
 

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -21,7 +21,7 @@ use Readonly;
 use FHEM::Meta;
 
 ############################################################    Default values
-Readonly our $VERSION               => q{3.0.9};
+Readonly our $VERSION               => q{3.0.10};
 Readonly our $DEFAULT_INTERVAL      => ONE_MINUTE * 2;
 Readonly our $DEBUGGING_MIN_VERBOSE => 2;
 Readonly our $DEFAULT_REGION        => q{de};
@@ -1130,7 +1130,7 @@ __END__
 
 =head1 VERSION
 
-    3.0.8
+    3.0.10
 
 =head1 SYNOPSIS
 
@@ -1655,7 +1655,7 @@ abgerufen werden.</code></pre>
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "3.0.8",
+    "version": "3.0.10",
     "author": [
         "Christoph Morrison <post@christoph-jeschke.de>"
     ],

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -157,7 +157,6 @@ sub initialize_module {
 
 sub handle_fhemweb_details {
     my $name            = shift;
-    my $page_definition = shift;
     my $hash            = get_device_definition($name);
 
     return if ( !defined( $hash->{URL} ) );

--- a/lib/FHEM/Weather/Buienradar.pm
+++ b/lib/FHEM/Weather/Buienradar.pm
@@ -257,7 +257,6 @@ sub handle_set {
     my $hash = shift;
     my $name = shift;
     my $opt  = shift;
-    my @args = shift;
 
     if ( !defined $opt ) {
         return qq{'set $name' needs at least one argument};

--- a/meta.json
+++ b/meta.json
@@ -16,7 +16,7 @@
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "3.1.0-10",
+    "version": "3.1.0-11",
     "author": [
         "Christoph 'knurd' Morrison <post@christoph-jeschke.de>"
     ],

--- a/meta.json
+++ b/meta.json
@@ -16,7 +16,7 @@
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "3.1.0-11",
+    "version": "3.1.0-12",
     "author": [
         "Christoph 'knurd' Morrison <post@christoph-jeschke.de>"
     ],

--- a/meta.json
+++ b/meta.json
@@ -58,7 +58,7 @@
         "runtime": {
             "requires": {
                 "FHEM": 5.00918799,
-                "perl": 5.0139,
+                "perl": 5.026,
                 "Meta": 0,
                 "JSON::MaybeXS": 0,
                 "Readonly": 0

--- a/meta.json
+++ b/meta.json
@@ -16,7 +16,7 @@
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "3.0.9",
+    "version": "3.1.0-10",
     "author": [
         "Christoph 'knurd' Morrison <post@christoph-jeschke.de>"
     ],

--- a/meta.json
+++ b/meta.json
@@ -16,7 +16,7 @@
     ],
     "release_status": "development",
     "license": "Unlicense",
-    "version": "3.1.0-12",
+    "version": "3.1.0-10",
     "author": [
         "Christoph 'knurd' Morrison <post@christoph-jeschke.de>"
     ],


### PR DESCRIPTION
# Pre-Release 3.1.0-10

## ⚠️ Important
* Perl version 5.26 is now the minimum version (#321)

## Content

### Bugs
* #324 Typo in Length
* #325 `&region` evaluates to `®ion`
* #327  Fixed double `return` statement
* #131 fixed startsIn if it's rainin right now reporting nothing back
* Fixed some typos

### Enhancements
* #326 Refactored the URL building
* #321 Perl > 5.26 is now mandatory
* #330 Importing POXIS without restrictions is not encouraged
* #332 Refactored debug messages
* #312 Support FHEMs `$init_done`
* #130 Added reading `rainBeginUnixtime` with the next rain as Unix timestamp (or -1 if no precipitation is predicted)
* Removed some unnecessarily defined variables